### PR TITLE
Replace FDI width defines with a single FDI_CONFIG parameter

### DIFF
--- a/DOC/MAS/aou_core_mas.md
+++ b/DOC/MAS/aou_core_mas.md
@@ -100,14 +100,15 @@ includes performance, power, and area information.
 The AOU_CORE is a bridge between AXI interface and the UCIe FDI
 interface, defined in AoU standard v0.7 spec.
 To achieve low latency, AOU_CORE directly handles signals related to the
-UCIe FDI interface data flow control and processes data in 64-byte or
-32-bytes chunks in a cut-through manner, without converting them to
-256-byte flit data. It receives AXI messages from its own AXI subordinate
-interface, packs them into 64-byte or 32-byte chunks, and transmits
-these chunks to the remote AoU device via UCIe. The remote AoU receives
-the 64-byte or 32-byte chunks from the UCIe FDI interface, unpacks them
-into AXI messages, and delivers the data through its AXI manager
-interface.
+UCIe FDI interface data flow control and processes data in 32-byte,
+64-byte, or 128-byte chunks (selected at integration time via the
+`FDI_CONFIG` parameter; see [Section 6.4](#64-configurable-parameters))
+in a cut-through manner, without converting them to 256-byte flit data.
+It receives AXI messages from its own AXI subordinate interface, packs
+them into chunks of the configured FDI width, and transmits these chunks
+to the remote AoU device via UCIe. The remote AoU receives the chunks
+from the UCIe FDI interface, unpacks them into AXI messages, and
+delivers the data through its AXI manager interface.
 The one-way AoU latency, measured from the AXI input of the local device
 to the AXI output of the remote device over a back-to-back connection in
 a single clock domain, is 7 cycles for read requests, 8 cycles for read
@@ -147,9 +148,12 @@ channels.
 The operating frequency of AOU_CORE targets 1 GHz and meets timing
 requirements without relying on multi-cycle paths. The TX buffer is
 configured with a minimal number of FIFO entries, while the RX Data
-buffer is designed with 88 entries to avoid any performance drop caused
-by AoU. The entry size takes into account the round-trip latency for
-credit consumption and return.
+buffer default depth is FDI-config aware: default 140 entries when `FDI_CONFIG`
+selects a 1024b (128B) FDI interface (`FDI_CFG_SP_128B` or
+`FDI_CFG_TP_64B_128B`), and default 88 entries otherwise. The entry size takes
+into account the round-trip latency for credit consumption and return,
+and matches the per-RP `RP*_RX_W_FIFO_DEPTH` / `RP*_RX_R_FIFO_DEPTH`
+parameter defaults documented in [Section 6.4](#64-configurable-parameters).
 
 # 2. Features
 
@@ -173,12 +177,17 @@ credit consumption and return.
 
 - UCIe 256B latency-optimized flit(Format 6) support only
 
-- Message packing and unpacking are handled in a unit of 64 bytes or 32
-  bytes, corresponding to the FDI data width (64B@1 GHz or 32@1 GHz).
+- Message packing and unpacking are handled in a unit of 32, 64, or
+  128 bytes, corresponding to the configured FDI data width
+  (32B@1 GHz, 64B@1 GHz, or 128B@1 GHz).
 
 - Selectable Early response by setting SFR
 
-- 64B and 32B FDI mode support
+- Selectable 32B / 64B / 128B single-PHY and 32B+64B / 64B+128B
+  two-PHY FDI configurations, selected via the `FDI_CONFIG` parameter
+  (see [Section 6.4](#64-configurable-parameters)). Two-PHY variants
+  additionally require the `+define+TWO_PHY` build flag so the
+  second-PHY ports physically exist.
 
 - Configurable number of Resource Plane and each RP's AXI data width
 
@@ -238,7 +247,11 @@ it to BUS. This functionality may modify AXI Len & Size. For example,
 AXI AR with 256-bit size & 16 burst length may transfer into 1024-bit
 size & 4 burst length. This operation can be controlled via SFR setting.
 
-AOU_CORE provides 64B FDI interface.
+AOU_CORE provides a parameterizable FDI interface; the data-path width
+is selected by `FDI_CONFIG` (`FDI_CFG_SP_32B` / `FDI_CFG_SP_64B` /
+`FDI_CFG_SP_128B` for single-PHY, `FDI_CFG_TP_32B_64B` /
+`FDI_CFG_TP_64B_128B` for two-PHY). See [Section 6.4](#64-configurable-parameters)
+for the full table of `FDI_CONFIG` values and resulting per-PHY widths.
 
 ## 3.2. TX_CORE
 
@@ -431,6 +444,13 @@ data width is 512 bits, each message is stored across two FIFO entries.
 Therefore, if the maximum turnaround time (TAT) to be covered is 50 ns
 (50 cycles), the depth can be set to 80 (50 / 1.25 x 2 = 80).
 Regarding the margin, Data FIFO's depth is set to 88.
+
+When `FDI_CONFIG` selects a 1024b (128B) FDI interface
+(`FDI_CFG_SP_128B` or `FDI_CFG_TP_64B_128B`), the per-chunk granule
+rate roughly doubles, so the per-RP `RP*_RX_W_FIFO_DEPTH` /
+`RP*_RX_R_FIFO_DEPTH` parameter defaults are bumped to 140 entries to
+keep the same effective TAT margin. See
+[Section 6.4](#64-configurable-parameters) for the parameter defaults.
 
 FIFOs are allocated for each RP, and the depth of the FIFOs for each RP
 is configurable.
@@ -1394,8 +1414,21 @@ activation sequence.
 # 6. Integration guide
 
 The details of integration for AOU_CORE are provided in this section.
-Number of AXI channels is configurable. I/O descriptions is for 2 AXI
-ports.
+Number of AXI channels is configurable: the `RP_COUNT` parameter
+defaults to 1 and is parameterizable up to 4. The I/O description in
+[Section 6.1](#61-io-descriptions) is shown for an example
+`RP_COUNT = 2` configuration.
+
+The AoU IP can be integrated either at `AOU_CORE_TOP` (the module
+documented in this MAS) or at the higher-level `AOU_TOP` wrapper, which
+adds the `AOU_FDI_BRINGUP_CTRL` block for turn-key UCIe FDI bringup.
+Both top modules share the same AXI, APB, FDI data-plane, interrupt,
+and DFT interfaces and forward the same `FDI_CONFIG` parameter (see
+[Section 6.4](#64-configurable-parameters)) through to AOU_CORE.
+For a side-by-side comparison of the two integration options see the
+companion *AOU Integration Guide*
+([`DOC/integration_guide/integration_guide.md`](../integration_guide/integration_guide.md)).
+The remainder of this MAS scopes itself to `AOU_CORE_TOP`.
 
 ## 6.1. I/O descriptions
 
@@ -2004,7 +2037,7 @@ ports.
 <td></td>
 </tr>
 <tr>
-<td>FDI interface (64B)</td>
+<td>FDI interface - PHY0 (always present; width = FDI_IF_WD0)</td>
 <td></td>
 <td></td>
 <td></td>
@@ -2013,127 +2046,139 @@ ports.
 <td></td>
 <td>input</td>
 <td></td>
-<td>I FDI PL 64B VALID</td>
+<td>I_FDI_PL_0_VALID</td>
 </tr>
 <tr>
 <td></td>
 <td>input</td>
-<td>[511:0]</td>
-<td>I_FDI PL 64B DATA</td>
-</tr>
-<tr>
-<td></td>
-<td>input</td>
-<td></td>
-<td>I FDI PL 64B FLIT CANCEL</td>
+<td>[FDI_IF_WD0-1:0]</td>
+<td>I_FDI_PL_0_DATA</td>
 </tr>
 <tr>
 <td></td>
 <td>input</td>
 <td></td>
-<td>I FDI PL 64B TRDY</td>
+<td>I_FDI_PL_0_FLIT_CANCEL</td>
 </tr>
 <tr>
 <td></td>
 <td>input</td>
 <td></td>
-<td>I FDI PL 64B STALLREQ</td>
-</tr>
-<tr>
-<td></td>
-<td>input</td>
-<td>[3:0]</td>
-<td>I FDI PL 64B STATE STS　</td>
-</tr>
-<tr>
-<td></td>
-<td>output</td>
-<td>[511:0]</td>
-<td>O FDI LP 64B DATA</td>
-</tr>
-<tr>
-<td></td>
-<td>output</td>
-<td></td>
-<td>O FDI LP 64B VALID</td>
-</tr>
-<tr>
-<td></td>
-<td>output</td>
-<td></td>
-<td>O FDI LP 64B IRDY</td>
-</tr>
-<tr>
-<td></td>
-<td>output</td>
-<td></td>
-<td>O FDI LP 64B STALLACK</td>
-</tr>
-<tr>
-<td>FDI interface (32B)</td>
-<td></td>
-<td></td>
-<td></td>
+<td>I_FDI_PL_0_TRDY</td>
 </tr>
 <tr>
 <td></td>
 <td>input</td>
 <td></td>
-<td>I FDI PL 32B VALID</td>
-</tr>
-<tr>
-<td></td>
-<td>input</td>
-<td>[255:0]</td>
-<td>I_FDI PL 32B DATA</td>
-</tr>
-<tr>
-<td></td>
-<td>input</td>
-<td></td>
-<td>I FDI PL 32B FLIT CANCEL</td>
-</tr>
-<tr>
-<td></td>
-<td>input</td>
-<td></td>
-<td>I FDI PL 32B TRDY</td>
-</tr>
-<tr>
-<td></td>
-<td>input</td>
-<td></td>
-<td>I FDI PL 32B STALLREQ</td>
+<td>I_FDI_PL_0_STALLREQ</td>
 </tr>
 <tr>
 <td></td>
 <td>input</td>
 <td>[3:0]</td>
-<td>I FDI PL 32B STATE STS　</td>
+<td>I_FDI_PL_0_STATE_STS</td>
 </tr>
 <tr>
 <td></td>
 <td>output</td>
-<td>[255:0]</td>
-<td>O FDI LP 32B DATA</td>
-</tr>
-<tr>
-<td></td>
-<td>output</td>
-<td></td>
-<td>O FDI LP 32B VALID</td>
+<td>[FDI_IF_WD0-1:0]</td>
+<td>O_FDI_LP_0_DATA</td>
 </tr>
 <tr>
 <td></td>
 <td>output</td>
 <td></td>
-<td>O FDI LP 32B IRDY</td>
+<td>O_FDI_LP_0_VALID</td>
 </tr>
 <tr>
 <td></td>
 <td>output</td>
 <td></td>
-<td>O FDI LP 32B STALLACK</td>
+<td>O_FDI_LP_0_IRDY</td>
+</tr>
+<tr>
+<td></td>
+<td>output</td>
+<td></td>
+<td>O_FDI_LP_0_STALLACK</td>
+</tr>
+<tr>
+<td>FDI interface - PHY1 (present only when +define+TWO_PHY; width = FDI_IF_WD1)</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td></td>
+<td>input</td>
+<td></td>
+<td>I_FDI_PL_1_VALID</td>
+</tr>
+<tr>
+<td></td>
+<td>input</td>
+<td>[FDI_IF_WD1-1:0]</td>
+<td>I_FDI_PL_1_DATA</td>
+</tr>
+<tr>
+<td></td>
+<td>input</td>
+<td></td>
+<td>I_FDI_PL_1_FLIT_CANCEL</td>
+</tr>
+<tr>
+<td></td>
+<td>input</td>
+<td></td>
+<td>I_FDI_PL_1_TRDY</td>
+</tr>
+<tr>
+<td></td>
+<td>input</td>
+<td></td>
+<td>I_FDI_PL_1_STALLREQ</td>
+</tr>
+<tr>
+<td></td>
+<td>input</td>
+<td>[3:0]</td>
+<td>I_FDI_PL_1_STATE_STS</td>
+</tr>
+<tr>
+<td></td>
+<td>output</td>
+<td>[FDI_IF_WD1-1:0]</td>
+<td>O_FDI_LP_1_DATA</td>
+</tr>
+<tr>
+<td></td>
+<td>output</td>
+<td></td>
+<td>O_FDI_LP_1_VALID</td>
+</tr>
+<tr>
+<td></td>
+<td>output</td>
+<td></td>
+<td>O_FDI_LP_1_IRDY</td>
+</tr>
+<tr>
+<td></td>
+<td>output</td>
+<td></td>
+<td>O_FDI_LP_1_STALLACK</td>
+</tr>
+<tr>
+<td>PHY type select (present only when +define+TWO_PHY)</td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td></td>
+<td>input</td>
+<td></td>
+<td>I_PHY_TYPE</td>
 </tr>
 <tr>
 <td>Activation related signal</td>
@@ -2287,8 +2332,25 @@ There are 2 reset: I_PRESETN and I_RESETN.
 </tr>
 <tr>
 <td>RP_COUNT</td>
-<td>2</td>
-<td>Equal to the count of RP.</td>
+<td>1</td>
+<td>Equal to the count of RP. Default 1; parameterizable up to 4.</td>
+</tr>
+<tr>
+<td>FDI_CONFIG</td>
+<td>FDI_CFG_SP_32B</td>
+<td>FDI width selector. Single integer parameter (named constants in
+<code>RTL/packet_def_pkg.sv</code>) replacing the legacy
+<code>FDI_IF_WD0</code>/<code>FDI_IF_WD1</code> width pair.<br />
+Valid values:<br />
+- <code>FDI_CFG_SP_32B</code> (0) - single PHY, WD0=256, WD1=512 (internal decode)<br />
+- <code>FDI_CFG_SP_64B</code> (1) - single PHY, WD0=512, WD1=512 (internal decode)<br />
+- <code>FDI_CFG_SP_128B</code> (2) - single PHY, WD0=1024, WD1=1024 (internal decode)<br />
+- <code>FDI_CFG_TP_32B_64B</code> (3) - two PHY, WD0=256, WD1=512 (requires <code>+define+TWO_PHY</code>)<br />
+- <code>FDI_CFG_TP_64B_128B</code> (4) - two PHY, WD0=512, WD1=1024 (requires <code>+define+TWO_PHY</code>)<br />
+The two-PHY values are valid only with the <code>+define+TWO_PHY</code> build flag, which gates the
+physical presence of the PHY1 ports and the <code>I_PHY_TYPE</code> selector. Consistency between
+<code>FDI_CONFIG</code> and <code>+define+TWO_PHY</code> is the integrator's responsibility; no in-RTL
+elaboration check is added.</td>
 </tr>
 <tr>
 <td>RP*_AXI_DATA_WD</td>
@@ -2311,7 +2373,10 @@ Turn-Around-Time(TAT) between the local die and the remote die, so that
 no performance drop occurs due to AoU.<br />
 TAT refers to the time in an environment integrated with UCIe, measured
 from when the local die sends a message until the credit is received
-back from the remote die.</td>
+back from the remote die.<br />
+The <code>RP*_RX_W_FIFO_DEPTH</code> and <code>RP*_RX_R_FIFO_DEPTH</code> defaults are FDI-config aware:
+140 entries when <code>FDI_CONFIG</code> selects a 1024b interface (<code>FDI_CFG_SP_128B</code> or
+<code>FDI_CFG_TP_64B_128B</code>); 88 entries otherwise.</td>
 </tr>
 <tr>
 <td>RP*_RX_AR_FIFO_DEPTH</td>
@@ -2319,15 +2384,39 @@ back from the remote die.</td>
 </tr>
 <tr>
 <td>RP*_RX_W_FIFO_DEPTH</td>
-<td>88</td>
+<td>88 / 140</td>
 </tr>
 <tr>
 <td>RP*_RX_R_FIFO_DEPTH</td>
-<td>88</td>
+<td>88 / 140</td>
 </tr>
 <tr>
 <td>RP*_RX_B_FIFO_DEPTH</td>
 <td>44</td>
+</tr>
+<tr>
+<td>RX_AW_FIFO_RS_EN</td>
+<td>1</td>
+<td rowspan="5">When 1, inserts an output register-slice on the corresponding RX FIFO read
+port. Trades latency (+1 cycle) for timing closure on the AXI manager
+output paths. Independently controllable per channel
+(AW / AR / W / R / B).</td>
+</tr>
+<tr>
+<td>RX_AR_FIFO_RS_EN</td>
+<td>1</td>
+</tr>
+<tr>
+<td>RX_W_FIFO_RS_EN</td>
+<td>1</td>
+</tr>
+<tr>
+<td>RX_R_FIFO_RS_EN</td>
+<td>1</td>
+</tr>
+<tr>
+<td>RX_B_FIFO_RS_EN</td>
+<td>1</td>
 </tr>
 <tr>
 <td>APB_ADDR_WD</td>
@@ -2371,6 +2460,12 @@ about requests received from the remote die.</td>
 </table>
 
 *Table 6. AOU_CORE_TOP Configurable Parameters*
+
+### Build flags
+
+| Flag | Effect |
+| :---- | :---- |
+| `+define+TWO_PHY` | Compile-time switch that adds the second-PHY ports (`I_FDI_PL_1_*`, `O_FDI_LP_1_*`) and the `I_PHY_TYPE` selector to both `AOU_CORE_TOP` and `AOU_TOP`. Required for the `FDI_CFG_TP_*` values of `FDI_CONFIG`. |
 
 # 7. Software operation guide
 
@@ -3250,7 +3345,10 @@ data respectively, occupy the largest portion of the AOU area. These
 FIFOs are currently implemented as register-based FIFOs.
 
 FIFO Depths : TX = 2 entries / RX = 88 entries for R/W data, and 44
-entries for AW/AR/B.
+entries for AW/AR/B. The 88-entry default for R/W data applies when
+`FDI_CONFIG` selects a non-1024b interface; the 1024b configurations
+(`FDI_CFG_SP_128B` / `FDI_CFG_TP_64B_128B`) default to 140 entries,
+which proportionally increases the R/W FIFO area component.
 The Expected R/W data for 128GBs/s is 176 entries.
 
 **v0.4 AOU_CORE**
@@ -3268,7 +3366,9 @@ The FIFO depth of the two RPs are identical.
 | 2RP<br />
 (AXI : 256bit &amp; 512bit) | 197K |
 
-*Table 10. AOU_CORE Area*
+*Table 10. AOU_CORE Area (measured at an `FDI_CFG_SP_64B`-equivalent
+configuration; numbers will scale up for `FDI_CFG_*_128B` configurations
+due to the 88 -> 140 R/W FIFO depth bump.)*
 
 # Appendix A. Records of Changes
 
@@ -3278,6 +3378,7 @@ The FIFO depth of the two RPs are identical.
 | v0.1 | 2025/08/20 | Soyoung Min, Jaeyun Lee, Hojun Lee | Kwanho Kim | Initial version. |
 | v0.2 | 2025/09/19 | Soyoung Min, Jaeyun Lee, Hojun Lee | Kwanho Kim | 256, 512, 1024 datawidth verification finished. Early response feature added. |
 |      | 2026/04/09 | Brad Erwin | | Expand explanation of early response feature |
+|      | 2026/04/22 | Tenstorrent | | Refresh with 128B FDI support documentation. New `FDI_CONFIG` parameter (single integer with named constants in `RTL/packet_def_pkg.sv`). FDI ports renamed from `_32B`/`_64B` to `_0`/`_1`; second-PHY ports and `I_PHY_TYPE` are gated by the `+define+TWO_PHY` build flag. New `AOU_TOP` wrapper introduced (adds `AOU_FDI_BRINGUP_CTRL` for turn-key FDI bringup). New `RX_*_FIFO_RS_EN` parameters control per-channel RX-FIFO output register-slices. `RP*_RX_W_FIFO_DEPTH` / `RP*_RX_R_FIFO_DEPTH` defaults are now FDI-config aware (140 entries for 1024b configurations, 88 otherwise). `RP_COUNT` default changed from 2 to 1. |
 
 *Table 11. Record of Changes*
 
@@ -3286,6 +3387,6 @@ The FIFO depth of the two RPs are identical.
 <a id="table-12"></a>
 | Document Name     | Document Location and/or URL      | Issuance Date  |
 |-------------------|-----------------------------------|----------------|
-| <Document Name> | < Document Location and/or URL> | <MM/DD/YYYY> |
+| AXI-over-UCIe (AoU) Specification, Revision 0.7 | [https://openchipletatlas.org](https://openchipletatlas.org) | 2025 |
 
 *Table 12. Referenced Documents*

--- a/DOC/integration_guide/integration_guide.md
+++ b/DOC/integration_guide/integration_guide.md
@@ -199,7 +199,11 @@ associated control/status signals listed in
 - Message packing and unpacking are handled in a unit of 64 bytes, corresponding to the
   FDI data width (64B@1 GHz).
 - Selectable Early response by setting SFR8
-- Selectable 32B and 64B FDI mode
+- Selectable 32B / 64B / 128B single-PHY and 32B+64B / 64B+128B two-PHY
+  FDI configurations via the `FDI_CONFIG` parameter (see
+  [Section 2](#2-parameter-list)). Two-PHY variants additionally require
+  the `+define+TWO_PHY` build flag so the second-PHY ports physically
+  exist.
 - Parameterized  number of Resource Plane and each RP’s AXI data width
 - RP Remapping
 - QoS scheme between RP with AW, W, AR channel
@@ -213,27 +217,33 @@ associated control/status signals listed in
 
 | Parameter | Type | Default / Note | Description |
 | :---- | :---- | :---- | :---- |
-| RP_COUNT | parameter | 2 | Number of receive ports (AXI M/S pairs). |
+| RP_COUNT | parameter | 1 | Number of receive ports (AXI M/S pairs). Parameterizable up to 4. |
+| FDI_CONFIG | parameter (int) | `FDI_CFG_SP_32B` | FDI width selector. See *FDI_CONFIG values* below. Two-PHY values additionally require `+define+TWO_PHY` at compile time. |
 | RP0_RX_AW_FIFO_DEPTH | parameter | 44 | RX AW FIFO depth for RP0. |
 | RP0_RX_AR_FIFO_DEPTH | parameter | 44 | RX AR FIFO depth for RP0. |
-| RP0_RX_W_FIFO_DEPTH | parameter | 88 | RX W FIFO depth for RP0. |
-| RP0_RX_R_FIFO_DEPTH | parameter | 88 | RX R FIFO depth for RP0. |
+| RP0_RX_W_FIFO_DEPTH | parameter | 88 / 140 | RX W FIFO depth for RP0. Default is 140 when `FDI_CONFIG` selects a 1024b interface (`FDI_CFG_SP_128B` / `FDI_CFG_TP_64B_128B`); 88 otherwise. |
+| RP0_RX_R_FIFO_DEPTH | parameter | 88 / 140 | RX R FIFO depth for RP0. Same FDI-aware default as `RP0_RX_W_FIFO_DEPTH`. |
 | RP0_RX_B_FIFO_DEPTH | parameter | 44 | RX B FIFO depth for RP0. |
 | RP1_RX_AW_FIFO_DEPTH | parameter | 44 | RX AW FIFO depth for RP1. |
 | RP1_RX_AR_FIFO_DEPTH | parameter | 44 | RX AR FIFO depth for RP1. |
-| RP1_RX_W_FIFO_DEPTH | parameter | 88 | RX W FIFO depth for RP1. |
-| RP1_RX_R_FIFO_DEPTH | parameter | 88 | RX R FIFO depth for RP1. |
+| RP1_RX_W_FIFO_DEPTH | parameter | 88 / 140 | RX W FIFO depth for RP1 (FDI-aware default; see RP0). |
+| RP1_RX_R_FIFO_DEPTH | parameter | 88 / 140 | RX R FIFO depth for RP1 (FDI-aware default; see RP0). |
 | RP1_RX_B_FIFO_DEPTH | parameter | 44 | RX B FIFO depth for RP1. |
 | RP2_RX_AW_FIFO_DEPTH | parameter | 44 | RX AW FIFO depth for RP2. |
 | RP2_RX_AR_FIFO_DEPTH | parameter | 44 | RX AR FIFO depth for RP2. |
-| RP2_RX_W_FIFO_DEPTH | parameter | 88 | RX W FIFO depth for RP2. |
-| RP2_RX_R_FIFO_DEPTH | parameter | 88 | RX R FIFO depth for RP2. |
+| RP2_RX_W_FIFO_DEPTH | parameter | 88 / 140 | RX W FIFO depth for RP2 (FDI-aware default; see RP0). |
+| RP2_RX_R_FIFO_DEPTH | parameter | 88 / 140 | RX R FIFO depth for RP2 (FDI-aware default; see RP0). |
 | RP2_RX_B_FIFO_DEPTH | parameter | 44 | RX B FIFO depth for RP2. |
 | RP3_RX_AW_FIFO_DEPTH | parameter | 44 | RX AW FIFO depth for RP3. |
 | RP3_RX_AR_FIFO_DEPTH | parameter | 44 | RX AR FIFO depth for RP3. |
-| RP3_RX_W_FIFO_DEPTH | parameter | 88 | RX W FIFO depth for RP3. |
-| RP3_RX_R_FIFO_DEPTH | parameter | 88 | RX R FIFO depth for RP3. |
+| RP3_RX_W_FIFO_DEPTH | parameter | 88 / 140 | RX W FIFO depth for RP3 (FDI-aware default; see RP0). |
+| RP3_RX_R_FIFO_DEPTH | parameter | 88 / 140 | RX R FIFO depth for RP3 (FDI-aware default; see RP0). |
 | RP3_RX_B_FIFO_DEPTH | parameter | 44 | RX B FIFO depth for RP3. |
+| RX_AW_FIFO_RS_EN | parameter | 1 | When 1, inserts an output register-slice on the RX AW FIFO read port. Trades latency (+1 cycle) for timing closure. |
+| RX_AR_FIFO_RS_EN | parameter | 1 | RX AR FIFO output register-slice enable (see `RX_AW_FIFO_RS_EN`). |
+| RX_W_FIFO_RS_EN | parameter | 1 | RX W FIFO output register-slice enable (see `RX_AW_FIFO_RS_EN`). |
+| RX_R_FIFO_RS_EN | parameter | 1 | RX R FIFO output register-slice enable (see `RX_AW_FIFO_RS_EN`). |
+| RX_B_FIFO_RS_EN | parameter | 1 | RX B FIFO output register-slice enable (see `RX_AW_FIFO_RS_EN`). |
 | RP0_AXI_DATA_WD | parameter | 512 | AXI data width for RP0 (bits). |
 | RP1_AXI_DATA_WD | parameter | 512 | AXI data width for RP1 (bits). |
 | RP2_AXI_DATA_WD | parameter | 512 | AXI data width for RP2 (bits). |
@@ -246,6 +256,42 @@ associated control/status signals listed in
 | M_RD_MO_CNT | parameter | 32 | Master read outstanding count. |
 | M_WR_MO_CNT | parameter | 32 | Master write outstanding count. |
 
+#### FDI_CONFIG values
+
+`FDI_CONFIG` is a single integer parameter that selects the FDI data
+width pair forwarded to the internal hierarchy. Named constants are
+declared in [`RTL/packet_def_pkg.sv`](../../RTL/packet_def_pkg.sv) and
+should be used at the instantiation site:
+
+| `FDI_CONFIG` value | PHY0 width (`FDI_IF_WD0`) | PHY1 width (`FDI_IF_WD1`) | PHY count | Build flag |
+| :---- | :---- | :---- | :---- | :---- |
+| `FDI_CFG_SP_32B` (default) | 256 | 512 (internal decode) | Single PHY | none |
+| `FDI_CFG_SP_64B` | 512 | 512 (internal decode) | Single PHY | none |
+| `FDI_CFG_SP_128B` | 1024 | 1024 (internal decode) | Single PHY | none |
+| `FDI_CFG_TP_32B_64B` | 256 | 512 | Two PHY | `+define+TWO_PHY` |
+| `FDI_CFG_TP_64B_128B` | 512 | 1024 | Two PHY | `+define+TWO_PHY` |
+
+Notes:
+
+- For single-PHY values, only the PHY0 ports
+  (`I_FDI_PL_0_*` / `O_FDI_LP_0_*`) carry traffic. The PHY1 internal
+  width is used only as the RX-side decode width.
+- The two-PHY values (`FDI_CFG_TP_*`) are valid **only** when the design
+  is built with `+define+TWO_PHY`. The build flag gates the physical
+  presence of the PHY1 ports (`I_FDI_PL_1_*`, `O_FDI_LP_1_*`) and the
+  `I_PHY_TYPE` selector on both `AOU_TOP` and `AOU_CORE_TOP`. Mixing a
+  `FDI_CFG_TP_*` value with a build that omits `+define+TWO_PHY` (or
+  vice-versa) is an integration error; the design does **not** enforce
+  this consistency at elaboration time.
+- The `FDI_CFG_TP_32B_128B` (256b + 1024b) combination is **not**
+  supported by the design: `AOU_RX_CORE_IN_MUX` requires
+  `FDI_IF_WD0 == FDI_IF_WD1 / 2` for two-PHY accumulation.
+
+#### Build flags
+
+| Flag | Effect |
+| :---- | :---- |
+| `+define+TWO_PHY` | Compile-time switch that adds the second-PHY ports (`I_FDI_PL_1_*`, `O_FDI_LP_1_*`) and the `I_PHY_TYPE` selector to both `AOU_TOP` and `AOU_CORE_TOP`. Required for `FDI_CFG_TP_*` values of `FDI_CONFIG`. |
 
 ---
 
@@ -384,29 +430,54 @@ associated control/status signals listed in
 
 ### 3.10 PHY and FDI (Flit Data Interface)
 
+The FDI port set is split into two banks: PHY0 (always present) and
+PHY1 (present only when the design is built with `+define+TWO_PHY`).
+Both banks use the parameterized widths derived from `FDI_CONFIG` (see
+[Section 2 - FDI_CONFIG values](#fdi_config-values)).
+
+| `FDI_CONFIG` | `FDI_IF_WD0` (PHY0 width) | `FDI_IF_WD1` (PHY1 width) | PHY1 ports present |
+| :---- | :---- | :---- | :---- |
+| `FDI_CFG_SP_32B` | 256 | 512 (internal decode) | no |
+| `FDI_CFG_SP_64B` | 512 | 512 (internal decode) | no |
+| `FDI_CFG_SP_128B` | 1024 | 1024 (internal decode) | no |
+| `FDI_CFG_TP_32B_64B` | 256 | 512 | yes (`+define+TWO_PHY`) |
+| `FDI_CFG_TP_64B_128B` | 512 | 1024 | yes (`+define+TWO_PHY`) |
+
+#### PHY0 (always present)
+
 | Signal | Direction | Width | Description |
 | :---- | :---- | :---- | :---- |
-| I_PHY_TYPE | input | 1 | PHY width mode (e.g., 32B vs 64B). |
-| I_FDI_PL_32B_VALID | input | 1 | 32B flit valid from PHY. |
-| I_FDI_PL_32B_DATA | input | 256 | 32B flit data. |
-| I_FDI_PL_32B_FLIT_CANCEL | input | 1 | 32B flit cancel. |
-| I_FDI_PL_64B_VALID | input | 1 | 64B flit valid from PHY. |
-| I_FDI_PL_64B_DATA | input | 512 | 64B flit data. |
-| I_FDI_PL_64B_FLIT_CANCEL | input | 1 | 64B flit cancel. |
-| I_FDI_PL_32B_TRDY | input | 1 | 32B PHY ready. |
-| I_FDI_PL_32B_STALLREQ | input | 1 | 32B stall request. |
-| I_FDI_PL_32B_STATE_STS | input | [3:0] | 32B state status. |
-| O_FDI_LP_32B_DATA | output | 256 | 32B flit data to PHY. |
-| O_FDI_LP_32B_VALID | output | 1 | 32B flit valid. |
-| O_FDI_LP_32B_IRDY | output | 1 | 32B link ready. |
-| O_FDI_LP_32B_STALLACK | output | 1 | 32B stall acknowledge. |
-| I_FDI_PL_64B_TRDY | input | 1 | 64B PHY ready. |
-| I_FDI_PL_64B_STALLREQ | input | 1 | 64B stall request. |
-| I_FDI_PL_64B_STATE_STS | input | [3:0] | 64B state status. |
-| O_FDI_LP_64B_DATA | output | 512 | 64B flit data to PHY. |
-| O_FDI_LP_64B_VALID | output | 1 | 64B flit valid. |
-| O_FDI_LP_64B_IRDY | output | 1 | 64B link ready. |
-| O_FDI_LP_64B_STALLACK | output | 1 | 64B stall acknowledge. |
+| I_FDI_PL_0_VALID | input | 1 | PHY0 flit valid from PHY. |
+| I_FDI_PL_0_DATA | input | `FDI_IF_WD0` | PHY0 flit data. |
+| I_FDI_PL_0_FLIT_CANCEL | input | 1 | PHY0 flit cancel. |
+| I_FDI_PL_0_TRDY | input | 1 | PHY0 ready. |
+| I_FDI_PL_0_STALLREQ | input | 1 | PHY0 stall request. |
+| I_FDI_PL_0_STATE_STS | input | [3:0] | PHY0 state status. |
+| O_FDI_LP_0_DATA | output | `FDI_IF_WD0` | PHY0 flit data to PHY. |
+| O_FDI_LP_0_VALID | output | 1 | PHY0 flit valid. |
+| O_FDI_LP_0_IRDY | output | 1 | PHY0 link ready. |
+| O_FDI_LP_0_STALLACK | output | 1 | PHY0 stall acknowledge. |
+
+#### PHY1 (present only when `+define+TWO_PHY`)
+
+| Signal | Direction | Width | Description |
+| :---- | :---- | :---- | :---- |
+| I_FDI_PL_1_VALID | input | 1 | PHY1 flit valid from PHY. |
+| I_FDI_PL_1_DATA | input | `FDI_IF_WD1` | PHY1 flit data. |
+| I_FDI_PL_1_FLIT_CANCEL | input | 1 | PHY1 flit cancel. |
+| I_FDI_PL_1_TRDY | input | 1 | PHY1 ready. |
+| I_FDI_PL_1_STALLREQ | input | 1 | PHY1 stall request. |
+| I_FDI_PL_1_STATE_STS | input | [3:0] | PHY1 state status. |
+| O_FDI_LP_1_DATA | output | `FDI_IF_WD1` | PHY1 flit data to PHY. |
+| O_FDI_LP_1_VALID | output | 1 | PHY1 flit valid. |
+| O_FDI_LP_1_IRDY | output | 1 | PHY1 link ready. |
+| O_FDI_LP_1_STALLACK | output | 1 | PHY1 stall acknowledge. |
+
+#### PHY type select (present only when `+define+TWO_PHY`)
+
+| Signal | Direction | Width | Description |
+| :---- | :---- | :---- | :---- |
+| I_PHY_TYPE | input | 1 | PHY selector for state-status / stall-request multiplexing: 0 = PHY0, 1 = PHY1. See [Section 6.6.4](#664-phy-type-mux). |
 
 ### 3.11 Interrupt and Error (to Error Handler)
 
@@ -811,18 +882,24 @@ The steps in detail:
 
 #### 6.6.4 PHY Type Mux
 
-`AOU_TOP` includes a PHY-type multiplexer controlled by `I_PHY_TYPE`:
+> **Note:** This PHY-type multiplexer is only present in builds compiled
+> with `+define+TWO_PHY`. In single-PHY builds, the `pl_state_sts` and
+> `pl_stallreq` signals routed to the bringup controller come from PHY0
+> unconditionally; the `I_PHY_TYPE` port and the PHY1-side ports do not
+> exist on the module boundary.
 
-| I_PHY_TYPE | PHY width | `pl_state_sts` source | `pl_stallreq` source |
+When built with `+define+TWO_PHY`, `AOU_TOP` includes a PHY-type
+multiplexer controlled by `I_PHY_TYPE`:
+
+| I_PHY_TYPE | Selected PHY | `pl_state_sts` source | `pl_stallreq` source |
 | :---- | :---- | :---- | :---- |
-| 0 | 32B (256-bit) | `I_FDI_PL_32B_STATE_STS` | `I_FDI_PL_32B_STALLREQ` |
-| 1 | 64B (512-bit) | `I_FDI_PL_64B_STATE_STS` | `I_FDI_PL_64B_STALLREQ` |
+| 0 | PHY0 (`FDI_IF_WD0`) | `I_FDI_PL_0_STATE_STS` | `I_FDI_PL_0_STALLREQ` |
+| 1 | PHY1 (`FDI_IF_WD1`) | `I_FDI_PL_1_STATE_STS` | `I_FDI_PL_1_STALLREQ` |
 
 The muxed `pl_state_sts` and `pl_stallreq` are routed to the bringup
 controller. FDI datapath signals (data, valid, trdy, etc.) pass through
 to `AOU_CORE_TOP` unchanged -- the core's `AOU_TX_FDI_IF` and
-`AOU_RX_FDI_IF` handle PHY-width-specific data path switching
-internally.
+`AOU_RX_FDI_IF` handle per-PHY data-path switching internally.
 
 #### 6.6.5 Software Bringup Control
 
@@ -855,7 +932,15 @@ gap analysis):
 
 ## 7 Verification Testbench
 
-A sample testbench (`VERIF/aou_tb.sv`) is provided that instantiates two AOU_CORE_TOP modules connected back-to-back via their 64B FDI interfaces, along with open-source AMBA AXI verification IP and a protocol-aware FDI flit decoder. The two DUT instances use different AXI data widths (512b and 256b) to exercise the interoperability path.  Refer to the README.md in the VERIF directory for additional information.
+A sample testbench (`VERIF/aou_tb.sv`) is provided that instantiates
+two `AOU_CORE_TOP` modules connected back-to-back via their 32B (256b)
+single-PHY FDI interfaces, along with open-source AMBA AXI verification
+IP and a protocol-aware FDI flit decoder. Each DUT is overridden with
+`.FDI_CONFIG(packet_def_pkg::FDI_CFG_SP_32B)`, and the testbench is
+built without `+define+TWO_PHY` (so only the PHY0 ports are connected).
+The two DUT instances use different AXI data widths (512b and 256b) to
+exercise the interoperability path. Refer to the README.md in the VERIF
+directory for additional information.
 
 ### 7.1 Architecture
 
@@ -867,7 +952,7 @@ A sample testbench (`VERIF/aou_tb.sv`) is provided that instantiates two AOU_COR
   +-----------------+      .      |  (AXI 512b)      |             | (512b)          |
   +-----------------+      .      +------------------+             +-----------------+
   | axi_scoreboard  |  .....              |      ^
-  | (monitor SI)    |              FDI 64B|      |FDI 64B
+  | (monitor SI)    |       FDI 32B (256b)|      |FDI 32B (256b)
   +-----------------+                     |      |
                                  fdi_dec1 |      | fdi_dec2
                                           v      |
@@ -884,7 +969,7 @@ A sample testbench (`VERIF/aou_tb.sv`) is provided that instantiates two AOU_COR
 The data flow for a write transaction initiated on `u_dut1`'s AXI slave interface is:
 
 1. `axi_rand_master` issues a 512b write on the `u_dut1` AXI SI.
-2. `u_dut1` packs the AXI transaction into AOU flit(s) and transmits via 64B FDI.
+2. `u_dut1` packs the AXI transaction into AOU flit(s) and transmits via the 32B (256b) PHY0 FDI port.
 3. `u_dut2` receives the FDI data, unpacks, and presents the transaction on its AXI MI.
 4. `axi_sim_mem_intf` accepts the write into its internal memory model.
 5. A subsequent read to the same address returns the stored data back through the reverse FDI path.
@@ -896,16 +981,16 @@ The reverse direction (initiated from `u_dut2` SI to `u_dut1` MI) operates symme
 
 | Component | Instance | Description |
 | :---- | :---- | :---- |
-| AOU_CORE_TOP | u_dut1 | DUT instance 1. AXI data width = 512b (default parameters). |
-| AOU_CORE_TOP | u_dut2 | DUT instance 2. RP0-RP3 AXI data widths overridden to 256b. |
+| AOU_CORE_TOP | u_dut1 | DUT instance 1. AXI data width = 512b (default parameters). `FDI_CONFIG = FDI_CFG_SP_32B` (256b PHY0; no TWO_PHY). |
+| AOU_CORE_TOP | u_dut2 | DUT instance 2. RP0-RP3 AXI data widths overridden to 256b. `FDI_CONFIG = FDI_CFG_SP_32B`. |
 | axi_rand_master | proc_axi_master_d1 | Constrained random AXI master on u_dut1 SI. Issues 512b transactions (1 beat, 64-byte aligned). |
 | axi_rand_master | proc_axi_master_d2 | Constrained random AXI master on u_dut2 SI. Issues 512b transactions (2 beats of 256b, 64-byte aligned). |
 | axi_sim_mem_intf | i_mem_d2mi | Memory-backed AXI slave on u_dut2 MI (256b). Stores writes and serves reads. |
 | axi_sim_mem_intf | i_mem_d1mi | Memory-backed AXI slave on u_dut1 MI (512b). Stores writes and serves reads. |
 | axi_scoreboard | proc_scoreboard_d1 | Monitors u_dut1 SI. Checks that read data matches previously written data. |
 | axi_scoreboard | proc_scoreboard_d2 | Monitors u_dut2 SI. Checks that read data matches previously written data. |
-| fdi_flit_decoder | u_fdi_dec1 | Logs and decodes FDI flits from u_dut1 TX to `dut1_fdi.log`. Enabled by `+define+AXI_LOG`. |
-| fdi_flit_decoder | u_fdi_dec2 | Logs and decodes FDI flits from u_dut2 TX to `dut2_fdi.log`. Enabled by `+define+AXI_LOG`. |
+| fdi_flit_decoder | u_fdi_dec1 | Logs and decodes FDI flits from u_dut1 TX to `dut1_fdi.log`. Configured with `FDI_BYTES(32)` to match `FDI_CFG_SP_32B`. Enabled by `+define+AXI_LOG`. |
+| fdi_flit_decoder | u_fdi_dec2 | Logs and decodes FDI flits from u_dut2 TX to `dut2_fdi.log`. Configured with `FDI_BYTES(32)` to match `FDI_CFG_SP_32B`. Enabled by `+define+AXI_LOG`. |
 
 Key testbench parameters:
 
@@ -1028,7 +1113,7 @@ The only CDC in AOU_CORE_TOP is between `clk_core` and `clk_apb`, handled by the
 
 ### 8.6 UPF Power Intent
 
-The current UPF defines a single always-on power domain (`PD_AOU_TOP`) covering the entire `AOU_CORE_TOP` scope with a `VDD`/`VSS` supply pair. No isolation, retention, or level-shifting strategies are required at this time. When power domains are introduced in the future, the UPF should be extended with `create_power_domain` for each switchable domain, along with appropriate isolation and retention strategies.
+The current UPF defines a single always-on power domain (`PD_AOU_TOP`) covering the integration scope (the `AOU_TOP` instance, which includes `AOU_CORE_TOP` and `AOU_FDI_BRINGUP_CTRL`, when integrating via `AOU_TOP`; or the `AOU_CORE_TOP` instance when integrating via `AOU_CORE_TOP` directly) with a `VDD`/`VSS` supply pair. No isolation, retention, or level-shifting strategies are required at this time. When power domains are introduced in the future, the UPF should be extended with `create_power_domain` for each switchable domain, along with appropriate isolation and retention strategies.
 
 ### 8.7 Library Cell Replacement
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open-source RTL implementation of the AXI-over-UCIe (AoU) protocol [[1]](#references), bridging AXI4 traffic [[3]](#references) over the Universal Chiplet Interconnect Express (UCIe) 3.0 Flit-Die Interface (FDI) [[2]](#references). This bridge enables native AXI transactions to traverse UCIe die-to-die interconnects, facilitating high-performance communication between heterogeneous chiplets in multi-die systems—such as CPUs, GPUs, AI accelerators, and custom IP blocks—without requiring protocol conversion through PCIe or CXL.
 
-The top-level module `AOU_CORE_TOP` provides AXI4 master and slave interfaces, an APB3 configuration port [[4]](#references), and 32B/64B FDI interfaces for integration into UCIe-based chiplet designs.
+Two top-level integration options are provided: `AOU_TOP` is a turn-key wrapper that includes an FDI bringup controller (`AOU_FDI_BRINGUP_CTRL`) for systems that want a self-contained UCIe FDI state machine, and `AOU_CORE_TOP` exposes the protocol engine directly for systems that already own the FDI bringup flow externally. Both top modules expose AXI4 master and slave interfaces, an APB3 configuration port [[4]](#references), and a parameterized FDI data plane: 32B / 64B / 128B FDI interfaces (single-PHY or two-PHY) selected via the `FDI_CONFIG` parameter for integration into UCIe-based chiplet designs.
 
 ## Directory Structure
 
@@ -12,7 +12,8 @@ RTL/                    Design source (SystemVerilog / Verilog)
   AXI4MUX_3X1/          AXI 3:1 mux / splitter / aggregator
 csr/                    SystemRDL register definitions
 DOC/                    Documentation
-  integration_guide/    AOU_CORE_TOP integration guide
+  integration_guide/    AOU_TOP / AOU_CORE_TOP integration guide
+  MAS/                  AOU_CORE micro-architecture specification
   csr/                  Generated register docs (Markdown, HTML, C header)
 INTEG/                  Integration collateral
   constraints/          SDC timing constraints and UPF power intent
@@ -51,7 +52,8 @@ See sections below for detailed documentation, integration guidance, and tool re
 
 ## Documentation
 
-- **[Integration Guide](DOC/integration_guide/AOU_CORE_TOP_integration_guide.md)** -- comprehensive guide covering module interfaces, register map, activation flow, debugging, verification, timing constraints, power intent, and library cell replacement.
+- **[Integration Guide](DOC/integration_guide/integration_guide.md)** -- comprehensive guide for `AOU_TOP` and `AOU_CORE_TOP` covering module interfaces, parameter list (including `FDI_CONFIG`), register map, activation flow, debugging, verification, timing constraints, power intent, and library cell replacement.
+- **[Micro-Architecture Specification](DOC/MAS/aou_core_mas.md)** -- AOU_CORE block-level architectural specification (datapaths, FIFO sizing, credit management, area, internal flows).
 - **[CSR Documentation](DOC/csr/README.md)** -- register map outputs (Markdown, C header, interactive HTML browser, IP-XACT, UVM model).
 - **Interactive HTML Register Browser** -- generated in `DOC/csr/html/` (see Tool Requirements below to generate).
 
@@ -85,12 +87,12 @@ This runs a dual-DUT FDI loopback simulation with AXI scoreboard-based data inte
 
 ## Integration
 
-For integrators bringing AOU_CORE_TOP into a chip design:
+For integrators bringing AOU_TOP or AOU_CORE_TOP into a chip design:
 
-- **[Integration Guide, Section 9](DOC/integration_guide/AOU_CORE_TOP_integration_guide.md#9-ip-integration-collateral)** covers all integration collateral: generated outputs, timing constraints (SDC), power intent (UPF), and library cell replacement guidance.
+- **[Integration Guide, Section 8](DOC/integration_guide/integration_guide.md#8-ip-integration-collateral)** covers all integration collateral: generated outputs, timing constraints (SDC), power intent (UPF), and library cell replacement guidance.
 - **Timing constraints**: `INTEG/constraints/aou_core_top.sdc` (1 GHz core, 100 MHz APB).
 - **Power intent**: `INTEG/constraints/aou_core_top.upf` (single always-on domain).
-- **Library cells** in `RTL/LIB/` are behavioral reference models that must be replaced with process-appropriate implementations before synthesis. See integration guide section 9.7 for details.
+- **Library cells** in `RTL/LIB/` are behavioral reference models that must be replaced with process-appropriate implementations before synthesis. See [integration guide Section 8.7](DOC/integration_guide/integration_guide.md#87-library-cell-replacement) for details.
 
 ## License
 

--- a/RTL/AOU_CORE.sv
+++ b/RTL/AOU_CORE.sv
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -93,11 +94,16 @@ module AOU_CORE #(
     parameter   M_RD_MO_CNT                 = 32,
     parameter   M_WR_MO_CNT                 = 32,
 
-    parameter   FDI_IF_WD0                  = 256,
+    parameter   FDI_IF_WD0                  = 512,
     parameter   FDI_IF_WD1                  = 512,
     parameter   RP_COUNT                    = 1,
     parameter   DEC_MULTI                   = 2,
     parameter   PHY_TYPE                    = 1,
+
+    // Active FDI width for RX decode: max of the two PHY widths. In both
+    // TWO_PHY and single-PHY configurations this matches the width the
+    // AOU_RX_CORE expects on its I_FDI_PL_DATA bus.
+    localparam  FDI_DEC_WD                  = (FDI_IF_WD0 > FDI_IF_WD1) ? FDI_IF_WD0 : FDI_IF_WD1,
 
     localparam  RP0_AXI_STRB_WD             = RP0_AXI_DATA_WD / 8,
     localparam  RP1_AXI_STRB_WD             = RP1_AXI_DATA_WD / 8,
@@ -106,7 +112,7 @@ module AOU_CORE #(
 
     localparam  RP_AXI_DATA_WD_MAX          = max4(RP0_AXI_DATA_WD, RP1_AXI_DATA_WD, RP2_AXI_DATA_WD, RP3_AXI_DATA_WD),
     localparam  RP_AXI_STRB_WD_MAX          = RP_AXI_DATA_WD_MAX / 8,
-    
+
     localparam  AXI_ADDR_WD                 = 64,
     localparam  AXI_ID_WD                   = 10,
     localparam  AXI_LEN_WD                  = 8,
@@ -242,18 +248,18 @@ module AOU_CORE #(
     input   [RP_COUNT-1:0][AXI_ID_WD-1:0]                   I_AOU_RX_WLAST_GEN_AWID,
     input   [RP_COUNT-1:0][AXI_ADDR_WD-1:0]                 I_AOU_RX_WLAST_GEN_AWADDR,
     input   [RP_COUNT-1:0][AXI_LEN_WD-1:0]                  I_AOU_RX_WLAST_GEN_AWLEN,
-    input   [RP_COUNT-1:0][2:0]                             I_AOU_RX_WLAST_GEN_AWSIZE,      
-    input   [RP_COUNT-1:0]                                  I_AOU_RX_WLAST_GEN_AWLOCK,      
-    input   [RP_COUNT-1:0][3:0]                             I_AOU_RX_WLAST_GEN_AWCACHE,     
-    input   [RP_COUNT-1:0][2:0]                             I_AOU_RX_WLAST_GEN_AWPROT,    
-    input   [RP_COUNT-1:0][3:0]                             I_AOU_RX_WLAST_GEN_AWQOS,     
-    input   [RP_COUNT-1:0]                                  I_AOU_RX_WLAST_GEN_AWVALID,       
-    output  [RP_COUNT-1:0]                                  O_AOU_RX_WLAST_GEN_AWREADY,     
-     
+    input   [RP_COUNT-1:0][2:0]                             I_AOU_RX_WLAST_GEN_AWSIZE,
+    input   [RP_COUNT-1:0]                                  I_AOU_RX_WLAST_GEN_AWLOCK,
+    input   [RP_COUNT-1:0][3:0]                             I_AOU_RX_WLAST_GEN_AWCACHE,
+    input   [RP_COUNT-1:0][2:0]                             I_AOU_RX_WLAST_GEN_AWPROT,
+    input   [RP_COUNT-1:0][3:0]                             I_AOU_RX_WLAST_GEN_AWQOS,
+    input   [RP_COUNT-1:0]                                  I_AOU_RX_WLAST_GEN_AWVALID,
+    output  [RP_COUNT-1:0]                                  O_AOU_RX_WLAST_GEN_AWREADY,
+
     input   [RP_COUNT-1:0][1:0]                             I_AOU_RX_WLAST_GEN_WDLENGTH,
     input   [RP_COUNT-1:0]                                  I_AOU_RX_WLAST_GEN_WDATAF,
-    input   [RP_COUNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0]    I_AOU_RX_WLAST_GEN_WDATA,    
-    input   [RP_COUNT-1:0][AXI_MAX_STRB_WD-1:0]             I_AOU_RX_WLAST_GEN_WSTRB,      
+    input   [RP_COUNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0]    I_AOU_RX_WLAST_GEN_WDATA,
+    input   [RP_COUNT-1:0][AXI_MAX_STRB_WD-1:0]             I_AOU_RX_WLAST_GEN_WSTRB,
     input   [RP_COUNT-1:0]                                  I_AOU_RX_WLAST_GEN_WVALID,
     output  [RP_COUNT-1:0]                                  O_AOU_RX_WLAST_GEN_WREADY,
 
@@ -264,27 +270,27 @@ module AOU_CORE #(
     output  [RP_COUNT-1:0]                                  O_EARLY_BRESP_CTRL_BREADY,
 
     //From aou_rx_ar_fifo
-    input   [RP_COUNT-1:0][AXI_ID_WD-1:0]                   I_AOU_RX_AXI_MM_ARID,        
+    input   [RP_COUNT-1:0][AXI_ID_WD-1:0]                   I_AOU_RX_AXI_MM_ARID,
     input   [RP_COUNT-1:0][AXI_ADDR_WD-1:0]                 I_AOU_RX_AXI_MM_ARADDR,
-    input   [RP_COUNT-1:0][AXI_LEN_WD-1:0]                  I_AOU_RX_AXI_MM_ARLEN,      
-    input   [RP_COUNT-1:0][2:0]                             I_AOU_RX_AXI_MM_ARSIZE,          
-    input   [RP_COUNT-1:0]                                  I_AOU_RX_AXI_MM_ARLOCK,      
-    input   [RP_COUNT-1:0][3:0]                             I_AOU_RX_AXI_MM_ARCACHE,     
-    input   [RP_COUNT-1:0][2:0]                             I_AOU_RX_AXI_MM_ARPROT,      
-    input   [RP_COUNT-1:0][3:0]                             I_AOU_RX_AXI_MM_ARQOS,       
-    input   [RP_COUNT-1:0]                                  I_AOU_RX_AXI_MM_ARVALID,     
+    input   [RP_COUNT-1:0][AXI_LEN_WD-1:0]                  I_AOU_RX_AXI_MM_ARLEN,
+    input   [RP_COUNT-1:0][2:0]                             I_AOU_RX_AXI_MM_ARSIZE,
+    input   [RP_COUNT-1:0]                                  I_AOU_RX_AXI_MM_ARLOCK,
+    input   [RP_COUNT-1:0][3:0]                             I_AOU_RX_AXI_MM_ARCACHE,
+    input   [RP_COUNT-1:0][2:0]                             I_AOU_RX_AXI_MM_ARPROT,
+    input   [RP_COUNT-1:0][3:0]                             I_AOU_RX_AXI_MM_ARQOS,
+    input   [RP_COUNT-1:0]                                  I_AOU_RX_AXI_MM_ARVALID,
     output  [RP_COUNT-1:0]                                  O_AOU_RX_AXI_MM_ARREADY,
 
     //Interface for AOU_RX_CORE FDI
     input                                                   I_FDI_PL_0_VALID,
-    input   [FDI_IF_WD0-1: 0]                               I_FDI_PL_0_DATA,            
+    input   [FDI_IF_WD0-1: 0]                               I_FDI_PL_0_DATA,
     input                                                   I_FDI_PL_0_FLIT_CANCEL,
 
 `ifdef TWO_PHY
     input                                                   I_PHY_TYPE,
 
     input                                                   I_FDI_PL_1_VALID,
-    input   [FDI_IF_WD1-1: 0]                               I_FDI_PL_1_DATA,            
+    input   [FDI_IF_WD1-1: 0]                               I_FDI_PL_1_DATA,
     input                                                   I_FDI_PL_1_FLIT_CANCEL,
 `endif
 
@@ -327,7 +333,7 @@ module AOU_CORE #(
     output  [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0]                                 O_RD_DATA_FIFO_SVALID,
 
     //Interface for Error Handler
-    output                                                O_ERR_INFO_RID_MISMATCH_ERR, 
+    output                                                O_ERR_INFO_RID_MISMATCH_ERR,
     output                                                O_ERR_INFO_SPLIT_BID_MISMATCH_ERR,
 
     output                                                O_AXI_SLV_RID_MISMATCH_ERROR,
@@ -434,7 +440,7 @@ module AOU_CORE #(
     localparam  CNT_RP_TX_AR_MAX_CREDIT_MAX = max4(CNT_RP0_TX_AR_MAX_CREDIT, CNT_RP1_TX_AR_MAX_CREDIT, CNT_RP2_TX_AR_MAX_CREDIT, CNT_RP3_TX_AR_MAX_CREDIT);
     localparam  CNT_RP_TX_W_MAX_CREDIT_MAX  = max4(CNT_RP0_TX_W_MAX_CREDIT,  CNT_RP1_TX_W_MAX_CREDIT,  CNT_RP2_TX_W_MAX_CREDIT,  CNT_RP3_TX_W_MAX_CREDIT);
     localparam  CNT_RP_TX_R_MAX_CREDIT_MAX  = max4(CNT_RP0_TX_R_MAX_CREDIT,  CNT_RP1_TX_R_MAX_CREDIT,  CNT_RP2_TX_R_MAX_CREDIT,  CNT_RP3_TX_R_MAX_CREDIT);
-    localparam  CNT_RP_TX_B_MAX_CREDIT_MAX  = max4(CNT_RP0_TX_B_MAX_CREDIT,  CNT_RP1_TX_B_MAX_CREDIT,  CNT_RP2_TX_B_MAX_CREDIT,  CNT_RP3_TX_B_MAX_CREDIT);  
+    localparam  CNT_RP_TX_B_MAX_CREDIT_MAX  = max4(CNT_RP0_TX_B_MAX_CREDIT,  CNT_RP1_TX_B_MAX_CREDIT,  CNT_RP2_TX_B_MAX_CREDIT,  CNT_RP3_TX_B_MAX_CREDIT);
 
 //----------------------------------------------------------------------------
     logic    [RP_COUNT-1:0]                               w_aou_slv_info_ar_hold_flag     ;
@@ -452,7 +458,7 @@ module AOU_CORE #(
     logic    [RP_COUNT-1:0][3:0]                          w_early_bresp_ctrl_awqos        ;
     logic    [RP_COUNT-1:0]                               w_early_bresp_ctrl_awvalid      ;
     logic    [RP_COUNT-1:0]                               w_early_bresp_ctrl_awready      ;
-    
+
     logic    [RP_COUNT-1:0][RP_AXI_DATA_WD_MAX-1:0]       w_early_bresp_ctrl_wdata        ;
     logic    [RP_COUNT-1:0][RP_AXI_STRB_WD_MAX-1:0]       w_early_bresp_ctrl_wstrb        ;
     logic    [RP_COUNT-1:0]                               w_early_bresp_ctrl_wlast        ;
@@ -467,15 +473,15 @@ module AOU_CORE #(
 
     logic    [3:0][1:0]                                   w_rp_dest_rp                    ;
 
-    logic    [3:0]                                        w_prior_rp_axi_axi_qos_to_np    ; 
-    logic    [3:0]                                        w_prior_rp_axi_axi_qos_to_hp    ; 
-    logic    [1:0]                                        w_prior_rp_axi_rp3_prior        ; 
-    logic    [1:0]                                        w_prior_rp_axi_rp2_prior        ; 
-    logic    [1:0]                                        w_prior_rp_axi_rp1_prior        ; 
-    logic    [1:0]                                        w_prior_rp_axi_rp0_prior        ; 
-    logic    [1:0]                                        w_prior_rp_axi_arb_mode         ; 
-    logic    [15:0]                                       w_prior_timer_timer_resolution  ; 
-    logic    [15:0]                                       w_prior_timer_timer_threshold   ; 
+    logic    [3:0]                                        w_prior_rp_axi_axi_qos_to_np    ;
+    logic    [3:0]                                        w_prior_rp_axi_axi_qos_to_hp    ;
+    logic    [1:0]                                        w_prior_rp_axi_rp3_prior        ;
+    logic    [1:0]                                        w_prior_rp_axi_rp2_prior        ;
+    logic    [1:0]                                        w_prior_rp_axi_rp1_prior        ;
+    logic    [1:0]                                        w_prior_rp_axi_rp0_prior        ;
+    logic    [1:0]                                        w_prior_rp_axi_arb_mode         ;
+    logic    [15:0]                                       w_prior_timer_timer_resolution  ;
+    logic    [15:0]                                       w_prior_timer_timer_threshold   ;
 
     logic    [3:0]                                        w_axi_slv_id_mismatch_en        ;
 //----------------------------------------------------------------------------
@@ -500,7 +506,7 @@ module AOU_CORE #(
     logic [DEC_MULTI-1:0][MAX_MISC_COUNT-1:0][2:0]  w_rxcore_crdtgrant_wreqcred1    ;
     logic [DEC_MULTI-1:0][MAX_MISC_COUNT-1:0][2:0]  w_rxcore_crdtgrant_wreqcred0    ;
     logic [DEC_MULTI-1:0][MAX_MISC_COUNT-1:0]       w_rxcore_crdtgrant_valid        ;
-        
+
     logic [1:0]                             w_rxcore_msgcrdt_wrespcred      ;
     logic [2:0]                             w_rxcore_msgcrdt_rdatacred      ;
     logic [2:0]                             w_rxcore_msgcrdt_wdatacred      ;
@@ -508,7 +514,7 @@ module AOU_CORE #(
     logic [2:0]                             w_rxcore_msgcrdt_wreqcred       ;
     logic [1:0]                             w_rxcore_msgcrdt_rp             ;
     logic                                   w_rxcore_msgcrdt_valid          ;
-        
+
     logic [2:0]                             w_txcore_msgcredit_wreqcred     ;
     logic [2:0]                             w_txcore_msgcredit_rreqcred     ;
     logic [2:0]                             w_txcore_msgcredit_wdatacred    ;
@@ -517,7 +523,7 @@ module AOU_CORE #(
     logic [1:0]                             w_txcore_msgcredit_rp           ;
     logic                                   w_txcore_msgcredit_cred_valid   ;
     logic                                   w_txcore_msgcredit_cred_ready   ;
-        
+
     logic [1:0]                             w_txcore_crdtgrant_wrespcred3   ;
     logic [1:0]                             w_txcore_crdtgrant_wrespcred2   ;
     logic [1:0]                             w_txcore_crdtgrant_wrespcred1   ;
@@ -540,14 +546,14 @@ module AOU_CORE #(
     logic [2:0]                             w_txcore_crdtgrant_wreqcred0    ;
     logic                                   w_txcore_crdtgrant_valid        ;
     logic                                   w_txcore_crdtgrant_ready        ;
-   
-    //interface 
+
+    //interface
     logic [RP_COUNT-1:0][CNT_RP_TX_AW_MAX_CREDIT_MAX-1:0] w_aou_tx_wreqcred ;
     logic [RP_COUNT-1:0][CNT_RP_TX_AR_MAX_CREDIT_MAX-1:0] w_aou_tx_rreqcred ;
     logic [RP_COUNT-1:0][CNT_RP_TX_W_MAX_CREDIT_MAX-1:0]  w_aou_tx_wdatacred;
     logic [RP_COUNT-1:0][CNT_RP_TX_R_MAX_CREDIT_MAX-1:0]  w_aou_tx_rdatacred;
     logic [RP_COUNT-1:0][CNT_RP_TX_B_MAX_CREDIT_MAX-1:0]  w_aou_tx_wrespcred;
-       
+
     logic [RP_COUNT-1:0]                    w_aou_tx_wreqvalid              ;
     logic [RP_COUNT-1:0]                    w_aou_tx_rreqvalid              ;
     logic [RP_COUNT-1:0]                    w_aou_tx_wdatavalid             ;
@@ -556,28 +562,28 @@ module AOU_CORE #(
     logic [RP_COUNT-1:0]                    w_aou_tx_rdatavalid             ;
     logic [RP_COUNT-1:0][1:0]               w_aou_tx_rdata_dlength          ;
     logic [RP_COUNT-1:0]                    w_aou_tx_wrespvalid             ;
-    
+
     logic                                   w_crd_count_en                  ;
-    logic                                   w_req_crd_advertise_en          ; 
+    logic                                   w_req_crd_advertise_en          ;
     logic                                   w_tx_req_credited_message_en    ;
-    logic                                   w_rsp_crd_advertise_en          ; 
+    logic                                   w_rsp_crd_advertise_en          ;
     logic                                   w_tx_rsp_credited_message_en    ;
-    
+
     logic                                   w_tx_credited_message_en        ;
     logic                                   w_status_disabled               ;
     logic                                   w_status_deactivate             ;
- 
+
     logic [3:0]                             w_txcore_activation_op          ;
     logic                                   w_txcore_activation_prop_req    ;
     logic                                   w_txcore_activation_valid       ;
     logic                                   w_txcore_activation_ready       ;
     logic                                   w_tx_pending                    ;
     logic                                   w_tx_axi_tr_pending             ;
-    
+
     logic [3:0]                             w_rxcore_activation_op          ;
     logic                                   w_rxcore_activation_prop_req    ;
     logic                                   w_rxcore_activation_valid       ;
-    
+
     logic [RP_COUNT-1:0][AXI_ID_WD-1:0]     w_aou_tx_axi_mm_rid             ;
     logic [RP_COUNT-1:0][1:0]               w_aou_tx_axi_mm_rdlen           ;
     logic [RP_COUNT-1:0][1023:0]            w_aou_tx_axi_mm_rdata           ;
@@ -585,17 +591,17 @@ module AOU_CORE #(
     logic [RP_COUNT-1:0]                    w_aou_tx_axi_mm_rlast           ;
     logic [RP_COUNT-1:0]                    w_aou_tx_axi_mm_rvalid          ;
     logic [RP_COUNT-1:0]                    w_aou_tx_axi_mm_rready          ;
-    
+
     logic [RP_COUNT-1:0][AXI_ID_WD-1:0]     w_aou_tx_axi_mm_bid_256         ;
     logic [RP_COUNT-1:0][1:0]               w_aou_tx_axi_mm_bresp_256       ;
     logic [RP_COUNT-1:0]                    w_aou_tx_axi_mm_bvalid_256      ;
     logic [RP_COUNT-1:0]                    w_aou_tx_axi_mm_bready_256      ;
-   
+
     logic [RP_COUNT-1:0][AXI_ID_WD-1:0]     w_aou_tx_axi_mm_bid_512         ;
     logic [RP_COUNT-1:0][1:0]               w_aou_tx_axi_mm_bresp_512       ;
     logic [RP_COUNT-1:0]                    w_aou_tx_axi_mm_bvalid_512      ;
     logic [RP_COUNT-1:0]                    w_aou_tx_axi_mm_bready_512      ;
-    
+
     logic [RP_COUNT-1:0][AXI_ID_WD-1:0]     w_aou_tx_axi_mm_bid_1024        ;
     logic [RP_COUNT-1:0][1:0]               w_aou_tx_axi_mm_bresp_1024      ;
     logic [RP_COUNT-1:0]                    w_aou_tx_axi_mm_bvalid_1024     ;
@@ -613,7 +619,7 @@ module AOU_CORE #(
     wire                                    w_deactivate_force              ;
     logic                                   w_int_activate_start            ;
     logic                                   w_int_deactivate_start          ;
-  
+
     logic [2:0]                             w_ack_time_out_value            ;
     logic [2:0]                             w_msgcredit_time_out_value      ;
     logic                                   w_act_ack_err_set               ;
@@ -621,20 +627,20 @@ module AOU_CORE #(
     logic [3:0]                             w_invalid_actmsg_opcode         ;
     logic                                   w_invalid_actmsg_err_set        ;
     logic                                   w_msgcredit_err_set             ;
-        
+
 //----------------------------------------------------------------------------
-     
+
     logic [3:0][31:0]                       w_debug_error_info_upper_addr;
     logic [3:0][31:0]                       w_debug_error_info_lower_addr;
     logic [3:0]                             w_debug_error_info_access_enable;
     logic [3:0]                             w_axi_aggregator_en;
-    
-//----------------------------------------------------------------------------    
+
+//----------------------------------------------------------------------------
     logic [3:0][AXI_ID_WD-1:0]      w_err_info_split_bid_mismatch, w_err_info_rid_mismatch;
     logic [3:0]                     w_err_split_bid_mismatch_set, w_err_rid_mismatch_set;
     logic [3:0][AXI_ID_WD-1:0]      w_axi_slv_bid_mismatch_info, w_axi_slv_rid_mismatch_info;
     logic [3:0]                     w_axi_slv_bid_mismatch_err_set, w_axi_slv_rid_mismatch_err_set;
-    
+
     logic [3:0]                     w_slv_tr_complete;
     logic [3:0]                     w_mst_tr_complete;
 
@@ -665,13 +671,13 @@ module AOU_CORE #(
     logic                           w_deact_ack_err_b       ;
     logic                           w_invalid_actmsg_err_b  ;
     logic                           w_msgcredit_err_b       ;
-    
-//---------------------------------------------------------------------------- 
-    logic             w_mst_rdata_eff_mon_active_rising_edge_detect ; 
-    logic             w_mst_wdata_eff_mon_active_rising_edge_detect ; 
-    logic             w_slv_rdata_eff_mon_active_rising_edge_detect ; 
-    logic             w_slv_wdata_eff_mon_active_rising_edge_detect ; 
-//---------------------------------------------------------------------------- 
+
+//----------------------------------------------------------------------------
+    logic             w_mst_rdata_eff_mon_active_rising_edge_detect ;
+    logic             w_mst_wdata_eff_mon_active_rising_edge_detect ;
+    logic             w_slv_rdata_eff_mon_active_rising_edge_detect ;
+    logic             w_slv_wdata_eff_mon_active_rising_edge_detect ;
+//----------------------------------------------------------------------------
      always_ff @ (posedge I_CLK or negedge I_RESETN) begin
         if (~I_RESETN) begin
             r_fdi_pl_0_stallreq <= 1'b0;
@@ -693,21 +699,21 @@ module AOU_CORE #(
 
     AOU_CORE_SFR #(
         .APB_ADDR_WD    ( APB_ADDR_WD   )
-    ) u_aou_core_sfr 
+    ) u_aou_core_sfr
     (
         .I_PCLK                                                         ( I_CLK                                 ),
         .I_PRESETN                                                      ( I_RESETN                              ),
-    
+
         .I_PSEL                                                         ( I_AOU_APB_SI0_PSEL                    ),
         .I_PENABLE                                                      ( I_AOU_APB_SI0_PENABLE                 ),
         .I_PADDR                                                        ( I_AOU_APB_SI0_PADDR                   ),
         .I_PWRITE                                                       ( I_AOU_APB_SI0_PWRITE                  ),
         .I_PWDATA                                                       ( I_AOU_APB_SI0_PWDATA                  ),
-    
+
         .O_PRDATA                                                       ( O_AOU_APB_SI0_PRDATA                  ),
         .O_PREADY                                                       ( O_AOU_APB_SI0_PREADY                  ),
         .O_PSLVERR                                                      ( O_AOU_APB_SI0_PSLVERR                 ),
-    
+
         .I_IP_VERSION_MAJOR_VERSION                                     ( 16'd1                                 ),
         .I_IP_VERSION_MINOR_VERSION                                     ( 16'b0                                 ),
 
@@ -738,8 +744,8 @@ module AOU_CORE #(
 
         .I_WRITE_EARLY_RESPONSE_RP0_WRITE_RESP_DONE                     ( w_early_bresp_done[0]                 ),
         .I_WRITE_EARLY_RESPONSE_RP0_WRITE_RESP_ERR_SET                  ( w_bresp_err[0]                        ),
-        .I_WRITE_EARLY_RESPONSE_RP0_WRITE_RESP_ERR_TYPE_INFO            ( w_bresp_err_type[0]                   ), 
-        .I_WRITE_EARLY_RESPONSE_RP0_WRITE_RESP_ERR_ID_INFO              ( w_bresp_err_id[0]                     ),    
+        .I_WRITE_EARLY_RESPONSE_RP0_WRITE_RESP_ERR_TYPE_INFO            ( w_bresp_err_type[0]                   ),
+        .I_WRITE_EARLY_RESPONSE_RP0_WRITE_RESP_ERR_ID_INFO              ( w_bresp_err_id[0]                     ),
         .O_WRITE_EARLY_RESPONSE_RP0_EARLY_BRESP_EN                      ( w_early_bresp_en[0]                   ),
 
         .O_LP_LINKRESET_ACK_TIME_OUT_VALUE                              ( w_ack_time_out_value                  ),
@@ -774,12 +780,12 @@ module AOU_CORE #(
         .O_DEACT_ACK_ERR                                                ( w_deact_ack_err                       ),
         .O_INVALID_ACTMSG_ERR                                           ( w_invalid_actmsg_err                  ),
         .O_MSGCREDIT_ERR                                                ( w_msgcredit_err                       ),
-    
-        .O_AXI_SLV_RID_MISMATCH_ERROR                                   ( w_axi_slv_rid_mismatch_error          ),    
+
+        .O_AXI_SLV_RID_MISMATCH_ERROR                                   ( w_axi_slv_rid_mismatch_error          ),
         .O_AXI_SLV_BID_MISMATCH_ERROR                                   ( w_axi_slv_bid_mismatch_error          ),
 
         .ERR_SLV_EARLY_RESP_ERR                                         ( w_int_slv_early_resp_err              ),
-        
+
         .INT_ACTIVATE_START                                             ( O_INT_ACTIVATE_START                  ),
         .INT_DEACTIVATE_START                                           ( O_INT_DEACTIVATE_START                ),
 
@@ -844,20 +850,20 @@ module AOU_CORE #(
         .O_DEST_RP_RP2_DEST                                             ( w_rp_dest_rp[2]                       ),
         .O_DEST_RP_RP1_DEST                                             ( w_rp_dest_rp[1]                       ),
         .O_DEST_RP_RP0_DEST                                             ( w_rp_dest_rp[0]                       ),
-        .O_PRIOR_RP_AXI_AXI_QOS_TO_NP                                   ( w_prior_rp_axi_axi_qos_to_np          ),    
-        .O_PRIOR_RP_AXI_AXI_QOS_TO_HP                                   ( w_prior_rp_axi_axi_qos_to_hp          ),    
-        .O_PRIOR_RP_AXI_RP3_PRIOR                                       ( w_prior_rp_axi_rp3_prior              ),    
-        .O_PRIOR_RP_AXI_RP2_PRIOR                                       ( w_prior_rp_axi_rp2_prior              ),    
-        .O_PRIOR_RP_AXI_RP1_PRIOR                                       ( w_prior_rp_axi_rp1_prior              ),        
-        .O_PRIOR_RP_AXI_RP0_PRIOR                                       ( w_prior_rp_axi_rp0_prior              ),    
-        .O_PRIOR_RP_AXI_ARB_MODE                                        ( w_prior_rp_axi_arb_mode               ),    
+        .O_PRIOR_RP_AXI_AXI_QOS_TO_NP                                   ( w_prior_rp_axi_axi_qos_to_np          ),
+        .O_PRIOR_RP_AXI_AXI_QOS_TO_HP                                   ( w_prior_rp_axi_axi_qos_to_hp          ),
+        .O_PRIOR_RP_AXI_RP3_PRIOR                                       ( w_prior_rp_axi_rp3_prior              ),
+        .O_PRIOR_RP_AXI_RP2_PRIOR                                       ( w_prior_rp_axi_rp2_prior              ),
+        .O_PRIOR_RP_AXI_RP1_PRIOR                                       ( w_prior_rp_axi_rp1_prior              ),
+        .O_PRIOR_RP_AXI_RP0_PRIOR                                       ( w_prior_rp_axi_rp0_prior              ),
+        .O_PRIOR_RP_AXI_ARB_MODE                                        ( w_prior_rp_axi_arb_mode               ),
         .O_PRIOR_TIMER_TIMER_RESOLUTION                                 ( w_prior_timer_timer_resolution        ),
         .O_PRIOR_TIMER_TIMER_THRESHOLD                                  ( w_prior_timer_timer_threshold         ),
 
-        .O_AXI_SLV_ID_MISMATCH_RP0_EN                                   ( w_axi_slv_id_mismatch_en[0]           ), 
-        .O_AXI_SLV_ID_MISMATCH_RP1_EN                                   ( w_axi_slv_id_mismatch_en[1]           ), 
-        .O_AXI_SLV_ID_MISMATCH_RP2_EN                                   ( w_axi_slv_id_mismatch_en[2]           ), 
-        .O_AXI_SLV_ID_MISMATCH_RP3_EN                                   ( w_axi_slv_id_mismatch_en[3]           ) 
+        .O_AXI_SLV_ID_MISMATCH_RP0_EN                                   ( w_axi_slv_id_mismatch_en[0]           ),
+        .O_AXI_SLV_ID_MISMATCH_RP1_EN                                   ( w_axi_slv_id_mismatch_en[1]           ),
+        .O_AXI_SLV_ID_MISMATCH_RP2_EN                                   ( w_axi_slv_id_mismatch_en[2]           ),
+        .O_AXI_SLV_ID_MISMATCH_RP3_EN                                   ( w_axi_slv_id_mismatch_en[3]           )
     );
 
     assign O_ERR_INFO_RID_MISMATCH_ERR          = w_mi0_id_mismatch_mask ? 1'b0 : w_err_info_rid_mismatch_err;
@@ -871,10 +877,10 @@ module AOU_CORE #(
     assign w_deact_ack_err_b        = w_deact_timeout_mask ? 1'b0 : w_deact_ack_err;
     assign w_invalid_actmsg_err_b   = w_invalid_actmsg_mask ? 1'b0 : w_invalid_actmsg_err;
     assign w_msgcredit_err_b        = w_msgcredit_timeout_mask ? 1'b0 : w_msgcredit_err;
-    
-    assign O_AOU_REQ_LINKRESET = w_act_ack_err_b || w_deact_ack_err_b || w_invalid_actmsg_err_b || w_msgcredit_err_b; 
 
-//----------------------------------------------------------------------------    
+    assign O_AOU_REQ_LINKRESET = w_act_ack_err_b || w_deact_ack_err_b || w_invalid_actmsg_err_b || w_msgcredit_err_b;
+
+//----------------------------------------------------------------------------
     AOU_CRD_CTRL #(
         .RP_COUNT               ( RP_COUNT              ),
 
@@ -883,61 +889,61 @@ module AOU_CORE #(
         .RP0_RX_W_MAX_CREDIT    ( RP0_RX_W_MAX_CREDIT   ),
         .RP0_RX_R_MAX_CREDIT    ( RP0_RX_R_MAX_CREDIT   ),
         .RP0_RX_B_MAX_CREDIT    ( RP0_RX_B_MAX_CREDIT   ),
-    
+
         .RP1_RX_AW_MAX_CREDIT   ( RP1_RX_AW_MAX_CREDIT  ),
         .RP1_RX_AR_MAX_CREDIT   ( RP1_RX_AR_MAX_CREDIT  ),
         .RP1_RX_W_MAX_CREDIT    ( RP1_RX_W_MAX_CREDIT   ),
         .RP1_RX_R_MAX_CREDIT    ( RP1_RX_R_MAX_CREDIT   ),
         .RP1_RX_B_MAX_CREDIT    ( RP1_RX_B_MAX_CREDIT   ),
-    
+
         .RP2_RX_AW_MAX_CREDIT   ( RP2_RX_AW_MAX_CREDIT  ),
         .RP2_RX_AR_MAX_CREDIT   ( RP2_RX_AR_MAX_CREDIT  ),
         .RP2_RX_W_MAX_CREDIT    ( RP2_RX_W_MAX_CREDIT   ),
         .RP2_RX_R_MAX_CREDIT    ( RP2_RX_R_MAX_CREDIT   ),
         .RP2_RX_B_MAX_CREDIT    ( RP2_RX_B_MAX_CREDIT   ),
-    
+
         .RP3_RX_AW_MAX_CREDIT   ( RP3_RX_AW_MAX_CREDIT  ),
         .RP3_RX_AR_MAX_CREDIT   ( RP3_RX_AR_MAX_CREDIT  ),
         .RP3_RX_W_MAX_CREDIT    ( RP3_RX_W_MAX_CREDIT   ),
         .RP3_RX_R_MAX_CREDIT    ( RP3_RX_R_MAX_CREDIT   ),
         .RP3_RX_B_MAX_CREDIT    ( RP3_RX_B_MAX_CREDIT   ),
-    
+
         .RP0_TX_AW_MAX_CREDIT   ( RP0_TX_AW_MAX_CREDIT  ),
         .RP0_TX_AR_MAX_CREDIT   ( RP0_TX_AR_MAX_CREDIT  ),
         .RP0_TX_W_MAX_CREDIT    ( RP0_TX_W_MAX_CREDIT   ),
         .RP0_TX_R_MAX_CREDIT    ( RP0_TX_R_MAX_CREDIT   ),
         .RP0_TX_B_MAX_CREDIT    ( RP0_TX_B_MAX_CREDIT   ),
-    
+
         .RP1_TX_AW_MAX_CREDIT   ( RP1_TX_AW_MAX_CREDIT  ),
         .RP1_TX_AR_MAX_CREDIT   ( RP1_TX_AR_MAX_CREDIT  ),
         .RP1_TX_W_MAX_CREDIT    ( RP1_TX_W_MAX_CREDIT   ),
         .RP1_TX_R_MAX_CREDIT    ( RP1_TX_R_MAX_CREDIT   ),
         .RP1_TX_B_MAX_CREDIT    ( RP1_TX_B_MAX_CREDIT   ),
 
-        .RP2_TX_AW_MAX_CREDIT   ( RP2_TX_AW_MAX_CREDIT  ),    
+        .RP2_TX_AW_MAX_CREDIT   ( RP2_TX_AW_MAX_CREDIT  ),
         .RP2_TX_AR_MAX_CREDIT   ( RP2_TX_AR_MAX_CREDIT  ),
         .RP2_TX_W_MAX_CREDIT    ( RP2_TX_W_MAX_CREDIT   ),
         .RP2_TX_R_MAX_CREDIT    ( RP2_TX_R_MAX_CREDIT   ),
         .RP2_TX_B_MAX_CREDIT    ( RP2_TX_B_MAX_CREDIT   ),
-    
+
         .RP3_TX_AW_MAX_CREDIT   ( RP3_TX_AW_MAX_CREDIT  ),
         .RP3_TX_AR_MAX_CREDIT   ( RP3_TX_AR_MAX_CREDIT  ),
         .RP3_TX_W_MAX_CREDIT    ( RP3_TX_W_MAX_CREDIT   ),
         .RP3_TX_R_MAX_CREDIT    ( RP3_TX_R_MAX_CREDIT   ),
         .RP3_TX_B_MAX_CREDIT    ( RP3_TX_B_MAX_CREDIT   ),
-    
+
         .RP0_AXI_DATA_WD        ( RP0_AXI_DATA_WD       ),
         .RP1_AXI_DATA_WD        ( RP1_AXI_DATA_WD       ),
         .RP2_AXI_DATA_WD        ( RP2_AXI_DATA_WD       ),
         .RP3_AXI_DATA_WD        ( RP3_AXI_DATA_WD       ),
 
         .DEC_MULTI              ( DEC_MULTI             )
-    
+
     ) u_aou_crd_ctrl
     (
         .I_CLK                          ( I_CLK                         ),
         .I_RESETN                       ( I_RESETN                      ),
-    
+
         .O_AOU_MSGCREDIT_WREQCRED       ( w_txcore_msgcredit_wreqcred   ),
         .O_AOU_MSGCREDIT_RREQCRED       ( w_txcore_msgcredit_rreqcred   ),
         .O_AOU_MSGCREDIT_WDATACRED      ( w_txcore_msgcredit_wdatacred  ),
@@ -946,7 +952,7 @@ module AOU_CORE #(
         .O_AOU_MSGCREDIT_RP             ( w_txcore_msgcredit_rp         ),
         .O_AOU_MSGCREDIT_CRED_VALID     ( w_txcore_msgcredit_cred_valid ),
         .I_AOU_MSGCREDIT_CRED_READY     ( w_txcore_msgcredit_cred_ready ),
-    
+
         .O_AOU_CRDTGRANT_WRESPCRED3     ( w_txcore_crdtgrant_wrespcred3 ),
         .O_AOU_CRDTGRANT_WRESPCRED2     ( w_txcore_crdtgrant_wrespcred2 ),
         .O_AOU_CRDTGRANT_WRESPCRED1     ( w_txcore_crdtgrant_wrespcred1 ),
@@ -969,7 +975,7 @@ module AOU_CORE #(
         .O_AOU_CRDTGRANT_WREQCRED0      ( w_txcore_crdtgrant_wreqcred0  ),
         .O_AOU_CRDTGRANT_VALID          ( w_txcore_crdtgrant_valid      ),
         .I_AOU_CRDTGRANT_READY          ( w_txcore_crdtgrant_ready      ),
-    
+
         .I_AOU_RX_WREQVALID             ( I_AOU_RX_WLAST_GEN_AWVALID & O_AOU_RX_WLAST_GEN_AWREADY & {RP_COUNT{(O_AOU_ACTIVATE_ST_ENABLED | w_status_deactivate)}}),
         .I_AOU_RX_RREQVALID             ( O_AOU_RX_AXI_MM_ARREADY & I_AOU_RX_AXI_MM_ARVALID & {RP_COUNT{(O_AOU_ACTIVATE_ST_ENABLED | w_status_deactivate)}}),
         .I_AOU_RX_WDATAVALID            ( I_AOU_RX_WLAST_GEN_WVALID & O_AOU_RX_WLAST_GEN_WREADY & {RP_COUNT{(O_AOU_ACTIVATE_ST_ENABLED | w_status_deactivate)}}),
@@ -978,13 +984,13 @@ module AOU_CORE #(
         .I_AOU_RX_RDATAVALID            ( I_AOU_RX_AXI_S_RREADY & I_AOU_RX_AXI_S_RVALID           ),
         .I_AOU_RX_RDATA_DLENGTH         ( I_AOU_RX_AXI_S_RDLENGTH       ),
         .I_AOU_RX_WRESPVALID            ( I_EARLY_BRESP_CTRL_BVALID & O_EARLY_BRESP_CTRL_BREADY   ),
-    
+
         .O_AOU_TX_WREQCRED              ( w_aou_tx_wreqcred             ),
         .O_AOU_TX_RREQCRED              ( w_aou_tx_rreqcred             ),
         .O_AOU_TX_WDATACRED             ( w_aou_tx_wdatacred            ),
         .O_AOU_TX_RDATACRED             ( w_aou_tx_rdatacred            ),
         .O_AOU_TX_WRESPCRED             ( w_aou_tx_wrespcred            ),
-    
+
         .I_AOU_TX_WREQVALID             ( w_aou_tx_wreqvalid            ),
         .I_AOU_TX_RREQVALID             ( w_aou_tx_rreqvalid            ),
         .I_AOU_TX_WDATAVALID            ( w_aou_tx_wdatavalid           ),
@@ -992,7 +998,7 @@ module AOU_CORE #(
         .I_AOU_TX_RDATAVALID            ( w_aou_tx_rdatavalid           ),
         .I_AOU_TX_RDATA_DLENGTH         ( w_aou_tx_rdata_dlength        ),
         .I_AOU_TX_WRESPVALID            ( w_aou_tx_wrespvalid           ),
-    
+
         .I_AOU_CRDTGRANT_WRESPCRED3     ( w_rxcore_crdtgrant_wrespcred3 ),
         .I_AOU_CRDTGRANT_WRESPCRED2     ( w_rxcore_crdtgrant_wrespcred2 ),
         .I_AOU_CRDTGRANT_WRESPCRED1     ( w_rxcore_crdtgrant_wrespcred1 ),
@@ -1014,7 +1020,7 @@ module AOU_CORE #(
         .I_AOU_CRDTGRANT_WREQCRED1      ( w_rxcore_crdtgrant_wreqcred1  ),
         .I_AOU_CRDTGRANT_WREQCRED0      ( w_rxcore_crdtgrant_wreqcred0  ),
         .I_AOU_CRDTGRANT_VALID          ( w_rxcore_crdtgrant_valid      ),
-    
+
         .I_AOU_MSGCRDT_WRESPCRED        ( w_rxcore_msgcrdt_wrespcred    ),
         .I_AOU_MSGCRDT_RDATACRED        ( w_rxcore_msgcrdt_rdatacred    ),
         .I_AOU_MSGCRDT_WDATACRED        ( w_rxcore_msgcrdt_wdatacred    ),
@@ -1022,14 +1028,14 @@ module AOU_CORE #(
         .I_AOU_MSGCRDT_WREQCRED         ( w_rxcore_msgcrdt_wreqcred     ),
         .I_AOU_MSGCRDT_RP               ( w_rxcore_msgcrdt_rp           ),
         .I_AOU_MSGCRDT_VALID            ( w_rxcore_msgcrdt_valid        ),
-    
+
         .I_CRD_COUNT_EN                 ( w_crd_count_en                ),
-    
-        .I_REQ_CRD_ADVERTISE_EN         ( w_req_crd_advertise_en        ), 
-        .I_TX_REQ_CREDITED_MESSAGE_EN   ( w_tx_req_credited_message_en  ), 
-        .I_RSP_CRD_ADVERTISE_EN         ( w_rsp_crd_advertise_en        ), 
-        .I_TX_RSP_CREDITED_MESSAGE_EN   ( w_tx_rsp_credited_message_en  ), 
-    
+
+        .I_REQ_CRD_ADVERTISE_EN         ( w_req_crd_advertise_en        ),
+        .I_TX_REQ_CREDITED_MESSAGE_EN   ( w_tx_req_credited_message_en  ),
+        .I_RSP_CRD_ADVERTISE_EN         ( w_rsp_crd_advertise_en        ),
+        .I_TX_RSP_CREDITED_MESSAGE_EN   ( w_tx_rsp_credited_message_en  ),
+
         .I_STATUS_DISABLE               ( w_status_disabled             ),
 
         .I_RP_DEST_RP                   ( w_rp_dest_rp                  ),
@@ -1037,28 +1043,28 @@ module AOU_CORE #(
         .I_CREDIT_BLOCK                 ( w_err_info_rid_mismatch_err | w_err_info_split_bid_mismatch_err | (|w_err_split_bid_mismatch_set) | (|w_err_rid_mismatch_set))
     );
 
-//----------------------------------------------------------------------------  
+//----------------------------------------------------------------------------
     logic   w_aou_rx_fifo_pending;
-    
+
     assign w_aou_rx_fifo_pending = (|I_AOU_RX_WLAST_GEN_AWVALID) | (|I_AOU_RX_AXI_MM_ARVALID) | (|I_AOU_RX_WLAST_GEN_WVALID) | (|I_EARLY_BRESP_CTRL_BVALID) | (|I_AOU_RX_AXI_S_RVALID);
-     
-    AOU_ACTIVATION_CTRL u_aou_activation_ctrl 
+
+    AOU_ACTIVATION_CTRL u_aou_activation_ctrl
     (
         .I_CLK                             ( I_CLK                          ),
         .I_RESETN                          ( I_RESETN                       ),
-    
+
         .I_UCIE_INIT_DONE                  ( I_INT_FSM_IN_ACTIVE            ),
         .I_ACTIVATE_START                  ( w_activate_start               ),
-    
+
         .I_ACTMSG_ACTIVATION_OP            ( w_rxcore_activation_op         ),
         .I_ACTMSG_PROPERTYREQ              ( w_rxcore_activation_prop_req   ),
         .I_ACTMSG_VALID                    ( w_rxcore_activation_valid      ),
-    
+
         .O_ACTMSG_ACTIVATION_OP            ( w_txcore_activation_op         ),
         .O_ACTMSG_PROPERTYREQ              ( w_txcore_activation_prop_req   ),
         .O_ACTMSG_VALID                    ( w_txcore_activation_valid      ),
         .I_ACTMSG_READY                    ( w_txcore_activation_ready      ),
-    
+
         .I_DEACTIVATE_TIME_OUT_VALUE       ( w_deactivate_time_out_value    ),
         .I_DEACTIVATE_START                ( w_deactivate_start             ),
         .I_DEACTIVATE_FORCE                ( w_deactivate_force             ),
@@ -1068,27 +1074,27 @@ module AOU_CORE #(
         .I_SLV_BUS_CLEANY_COMPLETE         ( O_SLV_TR_COMPLETE              ),
         .I_AOU_RX_NEW_TR_HS                ( (|O_RD_REQ_FIFO_SVALID) | (|O_WR_REQ_FIFO_SVALID)  ),
         .I_AOU_RX_FIFO_PENDING             ( w_aou_rx_fifo_pending          ),
-    
+
         .I_CRDTGRANT_VALID                 ( |w_rxcore_crdtgrant_valid      ),
-    
+
         .I_ACK_TIME_OUT_VALUE              (  w_ack_time_out_value          ),
         .I_MSGCREDIT_TIME_OUT_VALUE        (  w_msgcredit_time_out_value    ),
         .I_CREDIT_MANAGE_TYPE              (  w_credit_manage               ),
-    
+
         .O_ACT_ACK_ERR                     (  w_act_ack_err_set             ),
         .O_DEACT_ACK_ERR                   (  w_deact_ack_err_set           ),
         .O_INVALID_ACTMSG_INFO             (  w_invalid_actmsg_opcode       ),
         .O_INVALID_ACTMSG_ERR              (  w_invalid_actmsg_err_set      ),
-        .O_MSGCREDIT_ERR                   (  w_msgcredit_err_set           ),   
-    
+        .O_MSGCREDIT_ERR                   (  w_msgcredit_err_set           ),
+
         .O_CRD_COUNT_EN                    ( w_crd_count_en                 ),
-    
-        .O_REQ_CRD_ADVERTISE_EN            ( w_req_crd_advertise_en         ), 
-        .O_TX_REQ_CREDITED_MESSAGE_EN      ( w_tx_req_credited_message_en   ), 
-        .O_RSP_CRD_ADVERTISE_EN            ( w_rsp_crd_advertise_en         ), 
-        .O_TX_RSP_CREDITED_MESSAGE_EN      ( w_tx_rsp_credited_message_en   ), 
-    
-    
+
+        .O_REQ_CRD_ADVERTISE_EN            ( w_req_crd_advertise_en         ),
+        .O_TX_REQ_CREDITED_MESSAGE_EN      ( w_tx_req_credited_message_en   ),
+        .O_RSP_CRD_ADVERTISE_EN            ( w_rsp_crd_advertise_en         ),
+        .O_TX_RSP_CREDITED_MESSAGE_EN      ( w_tx_rsp_credited_message_en   ),
+
+
         .O_STATUS_DISABLED                 ( w_status_disabled              ),
         .O_STATUS_ENABLED                  ( O_AOU_ACTIVATE_ST_ENABLED      ),
         .O_STATUS_DEACTIVATE               ( w_status_deactivate            ),
@@ -1109,28 +1115,28 @@ module AOU_CORE #(
     logic [FDI_IF_WD1-1:0]               w_fdi_lp_data_1;
     logic                                w_fdi_lp_valid_1;
 `endif
-    
+
     AOU_TX_CORE #(
         .RP_CNT                         ( RP_COUNT                      ),
-    
+
         .FDI_IF_WD0                     ( FDI_IF_WD0                    ),
         .FDI_IF_WD1                     ( FDI_IF_WD1                    ),
         .RP0_AXI_DATA_WD                ( RP0_AXI_DATA_WD               ),
         .RP1_AXI_DATA_WD                ( RP1_AXI_DATA_WD               ),
         .RP2_AXI_DATA_WD                ( RP2_AXI_DATA_WD               ),
-        .RP3_AXI_DATA_WD                ( RP3_AXI_DATA_WD               ),  
+        .RP3_AXI_DATA_WD                ( RP3_AXI_DATA_WD               ),
         .MAX_AXI_DATA_WD                ( RP_AXI_DATA_WD_MAX            ),
- 
+
         .AXI_ADDR_WD                    ( AXI_ADDR_WD                   ),
         .AXI_ID_WD                      ( AXI_ID_WD                     ),
         .AXI_LEN_WD                     ( AXI_LEN_WD                    ),
-    
+
         .CNT_RP0_AW_MAX_CREDIT          ( CNT_RP0_TX_AW_MAX_CREDIT      ),
         .CNT_RP0_AR_MAX_CREDIT          ( CNT_RP0_TX_AR_MAX_CREDIT      ),
         .CNT_RP0_W_MAX_CREDIT           ( CNT_RP0_TX_W_MAX_CREDIT       ),
         .CNT_RP0_R_MAX_CREDIT           ( CNT_RP0_TX_R_MAX_CREDIT       ),
         .CNT_RP0_B_MAX_CREDIT           ( CNT_RP0_TX_B_MAX_CREDIT       ),
-    
+
         .CNT_RP1_AW_MAX_CREDIT          ( CNT_RP1_TX_AW_MAX_CREDIT      ),
         .CNT_RP1_AR_MAX_CREDIT          ( CNT_RP1_TX_AR_MAX_CREDIT      ),
         .CNT_RP1_W_MAX_CREDIT           ( CNT_RP1_TX_W_MAX_CREDIT       ),
@@ -1148,13 +1154,13 @@ module AOU_CORE #(
         .CNT_RP3_W_MAX_CREDIT           ( CNT_RP3_TX_W_MAX_CREDIT       ),
         .CNT_RP3_R_MAX_CREDIT           ( CNT_RP3_TX_R_MAX_CREDIT       ),
         .CNT_RP3_B_MAX_CREDIT           ( CNT_RP3_TX_B_MAX_CREDIT       )
-        
-    
+
+
     ) u_aou_tx_core
     (
         .I_CLK                          ( I_CLK                         ),
         .I_RESETN                       ( I_RESETN                      ),
-    
+
         .I_AOU_TX_AXI_AWID              ( w_early_bresp_ctrl_awid       ),
         .I_AOU_TX_AXI_AWADDR            ( w_early_bresp_ctrl_awaddr     ),
         .I_AOU_TX_AXI_AWLEN             ( w_early_bresp_ctrl_awlen      ),
@@ -1166,13 +1172,13 @@ module AOU_CORE #(
         .I_AOU_TX_AXI_AWQOS             ( w_early_bresp_ctrl_awqos      ),
         .I_AOU_TX_AXI_AWVALID           ( w_early_bresp_ctrl_awvalid    ),
         .O_AOU_TX_AXI_AWREADY           ( w_early_bresp_ctrl_awready    ),
-                                               
+
         .I_AOU_TX_AXI_WDATA             ( w_early_bresp_ctrl_wdata      ),
         .I_AOU_TX_AXI_WSTRB             ( w_early_bresp_ctrl_wstrb      ),
         .I_AOU_TX_AXI_WLAST             ( w_early_bresp_ctrl_wlast      ),
         .I_AOU_TX_AXI_WVALID            ( w_early_bresp_ctrl_wvalid     ),
         .O_AOU_TX_AXI_WREADY            ( w_early_bresp_ctrl_wready     ),
-    
+
         .I_AOU_TX_AXI_ARID              ( I_AOU_TX_AXI_S_ARID           ),
         .I_AOU_TX_AXI_ARADDR            ( I_AOU_TX_AXI_S_ARADDR         ),
         .I_AOU_TX_AXI_ARLEN             ( I_AOU_TX_AXI_S_ARLEN          ),
@@ -1184,22 +1190,22 @@ module AOU_CORE #(
         .I_AOU_TX_AXI_ARQOS             ( I_AOU_TX_AXI_S_ARQOS          ),
         .I_AOU_TX_AXI_ARVALID           ( w_aou_tx_axi_s_arvalid        ),
         .O_AOU_TX_AXI_ARREADY           ( w_aou_tx_axi_s_arready        ),
-    
+
         .I_AOU_TX_AXI_BID_256           ( w_aou_tx_axi_mm_bid_256       ),
         .I_AOU_TX_AXI_BRESP_256         ( w_aou_tx_axi_mm_bresp_256     ),
         .I_AOU_TX_AXI_BVALID_256        ( w_aou_tx_axi_mm_bvalid_256    ),
         .O_AOU_TX_AXI_BREADY_256        ( w_aou_tx_axi_mm_bready_256    ),
-    
+
         .I_AOU_TX_AXI_BID_512           ( w_aou_tx_axi_mm_bid_512       ),
         .I_AOU_TX_AXI_BRESP_512         ( w_aou_tx_axi_mm_bresp_512     ),
         .I_AOU_TX_AXI_BVALID_512        ( w_aou_tx_axi_mm_bvalid_512    ),
         .O_AOU_TX_AXI_BREADY_512        ( w_aou_tx_axi_mm_bready_512    ),
-    
+
         .I_AOU_TX_AXI_BID_1024          ( w_aou_tx_axi_mm_bid_1024      ),
         .I_AOU_TX_AXI_BRESP_1024        ( w_aou_tx_axi_mm_bresp_1024    ),
         .I_AOU_TX_AXI_BVALID_1024       ( w_aou_tx_axi_mm_bvalid_1024   ),
         .O_AOU_TX_AXI_BREADY_1024       ( w_aou_tx_axi_mm_bready_1024   ),
-    
+
         .I_AOU_TX_AXI_RID               ( w_aou_tx_axi_mm_rid           ),
         .I_AOU_TX_AXI_RDLEN             ( w_aou_tx_axi_mm_rdlen         ),
         .I_AOU_TX_AXI_RDATA             ( w_aou_tx_axi_mm_rdata         ),
@@ -1207,7 +1213,7 @@ module AOU_CORE #(
         .I_AOU_TX_AXI_RLAST             ( w_aou_tx_axi_mm_rlast         ),
         .I_AOU_TX_AXI_RVALID            ( w_aou_tx_axi_mm_rvalid        ),
         .O_AOU_TX_AXI_RREADY            ( w_aou_tx_axi_mm_rready        ),
-    
+
         .I_AOU_MSGCREDIT_WREQCRED       ( w_txcore_msgcredit_wreqcred   ),
         .I_AOU_MSGCREDIT_RREQCRED       ( w_txcore_msgcredit_rreqcred   ),
         .I_AOU_MSGCREDIT_WDATACRED      ( w_txcore_msgcredit_wdatacred  ),
@@ -1216,7 +1222,7 @@ module AOU_CORE #(
         .I_AOU_MSGCREDIT_RP             ( w_txcore_msgcredit_rp         ),
         .I_AOU_MSGCREDIT_CRED_VALID     ( w_txcore_msgcredit_cred_valid ),
         .O_AOU_MSGCREDIT_CRED_READY     ( w_txcore_msgcredit_cred_ready ),
-    
+
         .I_AOU_CRDTGRANT_WRESPCRED3     ( w_txcore_crdtgrant_wrespcred3 ),
         .I_AOU_CRDTGRANT_WRESPCRED2     ( w_txcore_crdtgrant_wrespcred2 ),
         .I_AOU_CRDTGRANT_WRESPCRED1     ( w_txcore_crdtgrant_wrespcred1 ),
@@ -1239,20 +1245,20 @@ module AOU_CORE #(
         .I_AOU_CRDTGRANT_WREQCRED0      ( w_txcore_crdtgrant_wreqcred0  ),
         .I_AOU_CRDTGRANT_VALID          ( w_txcore_crdtgrant_valid      ),
         .O_AOU_CRDTGRANT_READY          ( w_txcore_crdtgrant_ready      ),
-    
+
         .I_AOU_ACTIVATION_OP            ( w_txcore_activation_op        ),
         .I_AOU_ACTIVATION_PROP_REQ      ( w_txcore_activation_prop_req  ),
         .I_AOU_ACTIVATION_VALID         ( w_txcore_activation_valid     ),
         .O_AOU_ACTIVATION_READY         ( w_txcore_activation_ready     ),
         .O_AOU_TX_PENDING               ( w_tx_pending                  ),
         .O_AOU_TX_AXI_TR_PENDING        ( w_tx_axi_tr_pending           ),
-    
+
         .I_AOU_TX_WREQCRED              ( w_aou_tx_wreqcred             ),
         .I_AOU_TX_RREQCRED              ( w_aou_tx_rreqcred             ),
         .I_AOU_TX_WDATACRED             ( w_aou_tx_wdatacred            ),
         .I_AOU_TX_RDATACRED             ( w_aou_tx_rdatacred            ),
         .I_AOU_TX_WRESPCRED             ( w_aou_tx_wrespcred            ),
-    
+
         .O_AOU_TX_WREQVALID             ( w_aou_tx_wreqvalid            ),
         .O_AOU_TX_RREQVALID             ( w_aou_tx_rreqvalid            ),
         .O_AOU_TX_WDATAVALID            ( w_aou_tx_wdatavalid           ),
@@ -1260,7 +1266,7 @@ module AOU_CORE #(
         .O_AOU_TX_RDATAVALID            ( w_aou_tx_rdatavalid           ),
         .O_AOU_TX_RDATA_DLENGTH         ( w_aou_tx_rdata_dlength        ),
         .O_AOU_TX_WRESPVALID            ( w_aou_tx_wrespvalid           ),
-    
+
         .I_AOU_WRITEFULL_MSGTYPE_EN     ( 1'b1                          ),
 
         .I_AOU_TX_LP_MODE_THRESHOLD     ( w_tx_lp_mode_threshold        ),
@@ -1269,200 +1275,168 @@ module AOU_CORE #(
         .I_FDI_PL_TRDY_0                ( w_fdi_pl_trdy_0               ),
         .O_FDI_LP_DATA_0                ( w_fdi_lp_data_0               ),
         .O_FDI_LP_VALID_0               ( w_fdi_lp_valid_0              ),
- 
+
 `ifdef TWO_PHY
         .I_PHY_TYPE                     ( I_PHY_TYPE                    ),
-    
+
         .I_FDI_PL_TRDY_1                ( w_fdi_pl_trdy_1               ),
         .O_FDI_LP_DATA_1                ( w_fdi_lp_data_1               ),
         .O_FDI_LP_VALID_1               ( w_fdi_lp_valid_1              ),
-`endif        
-        
+`endif
+
         .I_STATUS_DISABLED              ( w_status_disabled             ),
         .I_RP_DEST_RP                   ( w_rp_dest_rp                  ),
 
-        .I_PRIOR_RP_AXI_AXI_QOS_TO_NP   ( w_prior_rp_axi_axi_qos_to_np  ), 
-        .I_PRIOR_RP_AXI_AXI_QOS_TO_HP   ( w_prior_rp_axi_axi_qos_to_hp  ), 
-        .I_PRIOR_RP_AXI_RP3_PRIOR       ( w_prior_rp_axi_rp3_prior      ), 
-        .I_PRIOR_RP_AXI_RP2_PRIOR       ( w_prior_rp_axi_rp2_prior      ), 
-        .I_PRIOR_RP_AXI_RP1_PRIOR       ( w_prior_rp_axi_rp1_prior      ), 
-        .I_PRIOR_RP_AXI_RP0_PRIOR       ( w_prior_rp_axi_rp0_prior      ), 
-        .I_PRIOR_RP_AXI_ARB_MODE        ( w_prior_rp_axi_arb_mode       ), 
-        .I_PRIOR_TIMER_TIMER_RESOLUTION ( w_prior_timer_timer_resolution), 
-        .I_PRIOR_TIMER_TIMER_THRESHOLD  ( w_prior_timer_timer_threshold ) 
+        .I_PRIOR_RP_AXI_AXI_QOS_TO_NP   ( w_prior_rp_axi_axi_qos_to_np  ),
+        .I_PRIOR_RP_AXI_AXI_QOS_TO_HP   ( w_prior_rp_axi_axi_qos_to_hp  ),
+        .I_PRIOR_RP_AXI_RP3_PRIOR       ( w_prior_rp_axi_rp3_prior      ),
+        .I_PRIOR_RP_AXI_RP2_PRIOR       ( w_prior_rp_axi_rp2_prior      ),
+        .I_PRIOR_RP_AXI_RP1_PRIOR       ( w_prior_rp_axi_rp1_prior      ),
+        .I_PRIOR_RP_AXI_RP0_PRIOR       ( w_prior_rp_axi_rp0_prior      ),
+        .I_PRIOR_RP_AXI_ARB_MODE        ( w_prior_rp_axi_arb_mode       ),
+        .I_PRIOR_TIMER_TIMER_RESOLUTION ( w_prior_timer_timer_resolution),
+        .I_PRIOR_TIMER_TIMER_THRESHOLD  ( w_prior_timer_timer_threshold )
 
     );
 
     AOU_TX_FDI_IF # (
-        .FDI_DATA_WD    ( FDI_IF_WD0   )    
+        .FDI_DATA_WD    ( FDI_IF_WD0   )
     ) u_aou_tx_fdi_if0 (
         .I_CLK                          ( I_CLK                     ),
         .I_RESETN                       ( I_RESETN                  ),
-    
+
         .I_AOU_TX_FLIT_DATA_VALID       ( w_fdi_lp_valid_0            ),
         .I_AOU_TX_FLIT_DATA             ( w_fdi_lp_data_0             ),
         .O_AOU_TX_FLIT_READY            ( w_fdi_pl_trdy_0             ),
-        
+
         .I_FDI_PL_TRDY                  ( I_FDI_PL_0_TRDY             ),
         .I_FDI_PL_STALLREQ              ( r_fdi_pl_0_stallreq         ),
-        .I_FDI_PL_STATE_STS             ( I_FDI_PL_0_STATE_STS        ), 
-        .O_FDI_LP_DATA                  ( O_FDI_LP_0_DATA             ), 
+        .I_FDI_PL_STATE_STS             ( I_FDI_PL_0_STATE_STS        ),
+        .O_FDI_LP_DATA                  ( O_FDI_LP_0_DATA             ),
         .O_FDI_LP_VALID                 ( O_FDI_LP_0_VALID            ),
-        .O_FDI_LP_IRDY                  ( O_FDI_LP_0_IRDY             ),     
-        .O_FDI_LP_STALLACK              ( O_FDI_LP_0_STALLACK         ) 
+        .O_FDI_LP_IRDY                  ( O_FDI_LP_0_IRDY             ),
+        .O_FDI_LP_STALLACK              ( O_FDI_LP_0_STALLACK         )
     );
-    
+
 `ifdef TWO_PHY
     AOU_TX_FDI_IF # (
-        .FDI_DATA_WD    ( FDI_IF_WD1   )    
+        .FDI_DATA_WD    ( FDI_IF_WD1   )
     ) u_aou_tx_fdi_if1 (
         .I_CLK                          ( I_CLK                     ),
         .I_RESETN                       ( I_RESETN                  ),
-        
+
         .I_AOU_TX_FLIT_DATA_VALID       ( w_fdi_lp_valid_1            ),
         .I_AOU_TX_FLIT_DATA             ( w_fdi_lp_data_1             ),
         .O_AOU_TX_FLIT_READY            ( w_fdi_pl_trdy_1             ),
-        
+
         .I_FDI_PL_TRDY                  ( I_FDI_PL_1_TRDY             ),
         .I_FDI_PL_STALLREQ              ( r_fdi_pl_1_stallreq         ),
-        .I_FDI_PL_STATE_STS             ( I_FDI_PL_1_STATE_STS        ), 
-        .O_FDI_LP_DATA                  ( O_FDI_LP_1_DATA             ), 
+        .I_FDI_PL_STATE_STS             ( I_FDI_PL_1_STATE_STS        ),
+        .O_FDI_LP_DATA                  ( O_FDI_LP_1_DATA             ),
         .O_FDI_LP_VALID                 ( O_FDI_LP_1_VALID            ),
-        .O_FDI_LP_IRDY                  ( O_FDI_LP_1_IRDY             ),     
-        .O_FDI_LP_STALLACK              ( O_FDI_LP_1_STALLACK         ) 
+        .O_FDI_LP_IRDY                  ( O_FDI_LP_1_IRDY             ),
+        .O_FDI_LP_STALLACK              ( O_FDI_LP_1_STALLACK         )
     );
 
 
 `endif
 
-//------------------------------------------------------------- 
+//-------------------------------------------------------------
+
+    // RX PHY->decode width adapter: instantiate a mux when TWO_PHY is
+    // enabled (mux both PHY streams) or when the single PHY is narrower than
+    // the decode width (the 32B primary-width case). Otherwise PHY0 data
+    // matches the decode width and is wired through directly.
+    logic                           w_fdi_pl_valid;
+    logic   [FDI_DEC_WD-1:0]        w_fdi_pl_data;
+    logic                           w_fdi_pl_flit_cancel;
 
 `ifdef TWO_PHY
-    logic                           w_fdi_pl_valid;
-    logic   [FDI_IF_WD1- 1: 0]      w_fdi_pl_data;
-    logic                           w_fdi_pl_flit_cancel;
-
-    `ifdef FDI_128B
-        AOU_RX_CORE_IN_MUX #(
-            .FDI_IF_WD                  ( FDI_IF_WD1                )
-        ) u_aou_rx_core_in_mux_128b
-        (
-            .I_CLK                      ( I_CLK                     ),
-            .I_RESETN                   ( I_RESETN                  ),
-            .I_PHY_TYPE                 ( I_PHY_TYPE                ),
-            .I_FDI_PL_1_VALID           ( I_FDI_PL_1_VALID        ),
-            .I_FDI_PL_1_DATA            ( I_FDI_PL_1_DATA         ),
-            .I_FDI_PL_1_FLIT_CANCEL     ( I_FDI_PL_1_FLIT_CANCEL  ),
-        
-            .I_FDI_PL_0_VALID           ( I_FDI_PL_0_VALID        ),
-            .I_FDI_PL_0_DATA            ( I_FDI_PL_0_DATA         ),
-            .I_FDI_PL_0_FLIT_CANCEL     ( I_FDI_PL_0_FLIT_CANCEL  ),
-        
-            .O_FDI_PL_VALID             ( w_fdi_pl_valid            ),
-            .O_FDI_PL_DATA              ( w_fdi_pl_data             ),
-            .O_FDI_PL_FLIT_CANCEL       ( w_fdi_pl_flit_cancel      )
-        );
-    `else
-        AOU_RX_CORE_IN_MUX #(
-            .FDI_IF_WD                  ( FDI_IF_WD1                )
-        ) u_aou_rx_core_in_mux_64b
-        (
-            .I_CLK                      ( I_CLK                     ),
-            .I_RESETN                   ( I_RESETN                  ),
-            .I_PHY_TYPE                 ( I_PHY_TYPE                ),
-            .I_FDI_PL_1_VALID         ( I_FDI_PL_1_VALID        ),
-            .I_FDI_PL_1_DATA          ( I_FDI_PL_1_DATA         ),
-            .I_FDI_PL_1_FLIT_CANCEL   ( I_FDI_PL_1_FLIT_CANCEL  ),
-        
-            .I_FDI_PL_0_VALID         ( I_FDI_PL_0_VALID        ),
-            .I_FDI_PL_0_DATA          ( I_FDI_PL_0_DATA         ),
-            .I_FDI_PL_0_FLIT_CANCEL   ( I_FDI_PL_0_FLIT_CANCEL  ),
-        
-            .O_FDI_PL_VALID             ( w_fdi_pl_valid            ),
-            .O_FDI_PL_DATA              ( w_fdi_pl_data             ),
-            .O_FDI_PL_FLIT_CANCEL       ( w_fdi_pl_flit_cancel      )
-        );
-    `endif
-`elsif FDI_32B
-    logic                           w_fdi_pl_valid;
-    logic   [FDI_IF_WD1- 1: 0]      w_fdi_pl_data;
-    logic                           w_fdi_pl_flit_cancel;
-
     AOU_RX_CORE_IN_MUX #(
-            .FDI_IF_WD              ( FDI_IF_WD1                )
-    ) u_aou_rx_core_in_mux_64b
+        .FDI_IF_WD                  ( FDI_DEC_WD                )
+    ) u_aou_rx_core_in_mux
     (
         .I_CLK                      ( I_CLK                     ),
         .I_RESETN                   ( I_RESETN                  ),
-        .I_PHY_TYPE                 ( 1'b0                      ),
-        .I_FDI_PL_1_VALID         ( '0                        ),
-        .I_FDI_PL_1_DATA          ( '0                        ),
-        .I_FDI_PL_1_FLIT_CANCEL   ( '0                        ),
-    
-        .I_FDI_PL_0_VALID         ( I_FDI_PL_0_VALID          ),
-        .I_FDI_PL_0_DATA          ( I_FDI_PL_0_DATA           ),
-        .I_FDI_PL_0_FLIT_CANCEL   ( I_FDI_PL_0_FLIT_CANCEL    ),
-    
+        .I_PHY_TYPE                 ( I_PHY_TYPE                ),
+        .I_FDI_PL_1_VALID           ( I_FDI_PL_1_VALID          ),
+        .I_FDI_PL_1_DATA            ( I_FDI_PL_1_DATA           ),
+        .I_FDI_PL_1_FLIT_CANCEL     ( I_FDI_PL_1_FLIT_CANCEL    ),
+
+        .I_FDI_PL_0_VALID           ( I_FDI_PL_0_VALID          ),
+        .I_FDI_PL_0_DATA            ( I_FDI_PL_0_DATA           ),
+        .I_FDI_PL_0_FLIT_CANCEL     ( I_FDI_PL_0_FLIT_CANCEL    ),
+
         .O_FDI_PL_VALID             ( w_fdi_pl_valid            ),
         .O_FDI_PL_DATA              ( w_fdi_pl_data             ),
         .O_FDI_PL_FLIT_CANCEL       ( w_fdi_pl_flit_cancel      )
     );
+`else
+    generate if (FDI_IF_WD0 < FDI_DEC_WD) begin : g_rx_mux_sp
+        AOU_RX_CORE_IN_MUX #(
+            .FDI_IF_WD              ( FDI_DEC_WD                )
+        ) u_aou_rx_core_in_mux
+        (
+            .I_CLK                  ( I_CLK                     ),
+            .I_RESETN               ( I_RESETN                  ),
+            .I_PHY_TYPE             ( 1'b0                      ),
+            .I_FDI_PL_1_VALID       ( '0                        ),
+            .I_FDI_PL_1_DATA        ( '0                        ),
+            .I_FDI_PL_1_FLIT_CANCEL ( '0                        ),
+
+            .I_FDI_PL_0_VALID       ( I_FDI_PL_0_VALID          ),
+            .I_FDI_PL_0_DATA        ( I_FDI_PL_0_DATA           ),
+            .I_FDI_PL_0_FLIT_CANCEL ( I_FDI_PL_0_FLIT_CANCEL    ),
+
+            .O_FDI_PL_VALID         ( w_fdi_pl_valid            ),
+            .O_FDI_PL_DATA          ( w_fdi_pl_data             ),
+            .O_FDI_PL_FLIT_CANCEL   ( w_fdi_pl_flit_cancel      )
+        );
+    end else begin : g_rx_direct
+        assign w_fdi_pl_valid       = I_FDI_PL_0_VALID;
+        assign w_fdi_pl_data        = I_FDI_PL_0_DATA;
+        assign w_fdi_pl_flit_cancel = I_FDI_PL_0_FLIT_CANCEL;
+    end endgenerate
 `endif
 
     AOU_RX_CORE #(
-        .DEC_MULTI                        ( DEC_MULTI                         ),  
+        .DEC_MULTI                        ( DEC_MULTI                         ),
         .PHY_TYPE                         ( PHY_TYPE                          ),
-        `ifdef TWO_PHY
-            .FDI_IF_WD                    ( FDI_IF_WD1                        ),
-        `elsif FDI_32B
-            .FDI_IF_WD                    ( FDI_IF_WD1                        ),
-        `else
-            .FDI_IF_WD                    ( FDI_IF_WD0                        ),
-        `endif    
+        .FDI_IF_WD                        ( FDI_DEC_WD                        ),
 
         .AXI_PEER_DIE_MAX_DATA_WD           ( AXI_PEER_DIE_MAX_DATA_WD          ),
-        .AXI_ADDR_WD                        ( AXI_ADDR_WD                       ),    
-        .AXI_ID_WD                          ( AXI_ID_WD                         ),    
+        .AXI_ADDR_WD                        ( AXI_ADDR_WD                       ),
+        .AXI_ID_WD                          ( AXI_ID_WD                         ),
         .AXI_LEN_WD                         ( AXI_LEN_WD                        ),
-    
-        .RP_COUNT                           ( RP_COUNT                          ),       
+
+        .RP_COUNT                           ( RP_COUNT                          ),
         .AW_AR_FIFO_DATA_WIDTH              ( AW_AR_FIFO_WIDTH                  ),
         .B_FIFO_DATA_WIDTH                  ( B_FIFO_WIDTH                      ),
         .R_FIFO_EXT_DATA_WIDTH              ( R_FIFO_EXT_DATA_WIDTH             )
-    
+
     ) u_aou_rx_core
     (
         .I_CLK                              ( I_CLK                             ),
         .I_RESETN                           ( I_RESETN                          ),
-                              
-`ifdef TWO_PHY
+
         .I_FDI_PL_VALID                     ( w_fdi_pl_valid                    ),
-        .I_FDI_PL_DATA                      ( w_fdi_pl_data                     ),          
+        .I_FDI_PL_DATA                      ( w_fdi_pl_data                     ),
         .I_FDI_PL_FLIT_CANCEL               ( w_fdi_pl_flit_cancel              ),
-`elsif FDI_32B
-        .I_FDI_PL_VALID                     ( w_fdi_pl_valid                    ),
-        .I_FDI_PL_DATA                      ( w_fdi_pl_data                     ),          
-        .I_FDI_PL_FLIT_CANCEL               ( w_fdi_pl_flit_cancel              ),
-`else
-        .I_FDI_PL_VALID                     ( I_FDI_PL_0_VALID                  ),
-        .I_FDI_PL_DATA                      ( I_FDI_PL_0_DATA                   ),          
-        .I_FDI_PL_FLIT_CANCEL               ( I_FDI_PL_0_FLIT_CANCEL            ),
-`endif
-       
+
         .O_RD_REQ_FIFO_SDATA                ( O_RD_REQ_FIFO_SDATA               ),
         .O_RD_REQ_FIFO_SVALID               ( O_RD_REQ_FIFO_SVALID              ),
-    
+
         .O_WR_REQ_FIFO_SDATA                ( O_WR_REQ_FIFO_SDATA               ),
         .O_WR_REQ_FIFO_SVALID               ( O_WR_REQ_FIFO_SVALID              ),
-    
+
         .O_WR_DATA_FIFO_SDATA               ( O_WR_DATA_FIFO_SDATA              ),
-        .O_WR_DATA_FIFO_SDATA_STRB          ( O_WR_DATA_FIFO_SDATA_STRB         ), 
-        .O_WR_DATA_FIFO_SDATA_WDATAF        ( O_WR_DATA_FIFO_SDATA_WDATAF       ), 
+        .O_WR_DATA_FIFO_SDATA_STRB          ( O_WR_DATA_FIFO_SDATA_STRB         ),
+        .O_WR_DATA_FIFO_SDATA_WDATAF        ( O_WR_DATA_FIFO_SDATA_WDATAF       ),
         .O_WR_DATA_FIFO_SVALID              ( O_WR_DATA_FIFO_SVALID             ),
-    
+
         .O_WR_RESP_FIFO_SDATA               ( O_WR_RESP_FIFO_SDATA              ),
         .O_WR_RESP_FIFO_SVALID              ( O_WR_RESP_FIFO_SVALID             ),
-    
+
         .O_RD_DATA_FIFO_SDATA               ( O_RD_DATA_FIFO_SDATA              ),
         .O_RD_DATA_FIFO_EXT_SDATA           ( O_RD_DATA_FIFO_EXT_SDATA          ),
         .O_RD_DATA_FIFO_SVALID              ( O_RD_DATA_FIFO_SVALID             ),
@@ -1488,7 +1462,7 @@ module AOU_CORE #(
         .O_CRDTGRANT_WREQCRED1              ( w_rxcore_crdtgrant_wreqcred1      ),
         .O_CRDTGRANT_WREQCRED0              ( w_rxcore_crdtgrant_wreqcred0      ),
         .O_CRDTGRANT_VALID                  ( w_rxcore_crdtgrant_valid          ),
-                                                                     
+
         .O_MSGCRDT_WRESPCRED                ( w_rxcore_msgcrdt_wrespcred        ),
         .O_MSGCRDT_RDATACRED                ( w_rxcore_msgcrdt_rdatacred        ),
         .O_MSGCRDT_WDATACRED                ( w_rxcore_msgcrdt_wdatacred        ),
@@ -1496,22 +1470,22 @@ module AOU_CORE #(
         .O_MSGCRDT_WREQCRED                 ( w_rxcore_msgcrdt_wreqcred         ),
         .O_MSGCRDT_RP                       ( w_rxcore_msgcrdt_rp               ),
         .O_MSGCRDT_VALID                    ( w_rxcore_msgcrdt_valid            ),
-        
+
         .O_ACTIVATION_OP                    ( w_rxcore_activation_op            ),
         .O_ACTIVATION_PROP_REQ              ( w_rxcore_activation_prop_req      ),
         .O_ACTIVATION_VALID                 ( w_rxcore_activation_valid         )
     );
 
 //-------------------------------------------------------------
-    
+
     assign O_AOU_ACTIVATE_ST_DISABLED = w_status_disabled;
-    
+
     genvar i;
-    generate 
+    generate
         for(i = 0; i < RP_COUNT; i++) begin : gen_aou_core_rp
             if(RP_AXI_DATA_WD_MAX > RP_AXI_DATA_WD[i]) begin: GEN_PAD
-                assign O_AOU_RX_AXI_M_WDATA[i][RP_AXI_DATA_WD_MAX-1:RP_AXI_DATA_WD[i]]      = 'd0; 
-                assign O_AOU_RX_AXI_M_WSTRB[i][RP_AXI_STRB_WD_MAX-1:RP_AXI_STRB_WD[i]]      = 'd0;  
+                assign O_AOU_RX_AXI_M_WDATA[i][RP_AXI_DATA_WD_MAX-1:RP_AXI_DATA_WD[i]]      = 'd0;
+                assign O_AOU_RX_AXI_M_WSTRB[i][RP_AXI_STRB_WD_MAX-1:RP_AXI_STRB_WD[i]]      = 'd0;
                 assign w_early_bresp_ctrl_wdata[i][RP_AXI_DATA_WD_MAX-1:RP_AXI_DATA_WD[i]]  = 'd0;
                 assign w_early_bresp_ctrl_wstrb[i][RP_AXI_STRB_WD_MAX-1:RP_AXI_STRB_WD[i]]  = 'd0;
             end
@@ -1520,20 +1494,20 @@ module AOU_CORE #(
             assign w_aou_tx_axi_s_arvalid[i] = I_AOU_TX_AXI_S_ARVALID[i] && ~w_aou_slv_info_ar_hold_flag[i];
 
             AOU_CORE_RP #(
-                .AXI_DATA_WD              (RP_AXI_DATA_WD[i]), 
-                .AXI_PEER_DIE_MAX_DATA_WD (AXI_PEER_DIE_MAX_DATA_WD), 
-                                          
-                .S_RD_MO_CNT              (S_RD_MO_CNT), 
+                .AXI_DATA_WD              (RP_AXI_DATA_WD[i]),
+                .AXI_PEER_DIE_MAX_DATA_WD (AXI_PEER_DIE_MAX_DATA_WD),
+
+                .S_RD_MO_CNT              (S_RD_MO_CNT),
                 .S_WR_MO_CNT              (S_WR_MO_CNT),
 
-                .M_RD_MO_CNT              (M_RD_MO_CNT), 
-                .M_WR_MO_CNT              (M_WR_MO_CNT) 
- 
-            ) u_aou_core_rp 
+                .M_RD_MO_CNT              (M_RD_MO_CNT),
+                .M_WR_MO_CNT              (M_WR_MO_CNT)
+
+            ) u_aou_core_rp
             (
                 .I_CLK                                     ( I_CLK                             ),
                 .I_RESETN                                  ( I_RESETN                          ),
-                                                                                            
+
                 .O_AOU_RX_AXI_M_ARID                       ( O_AOU_RX_AXI_M_ARID[i]            ),
                 .O_AOU_RX_AXI_M_ARADDR                     ( O_AOU_RX_AXI_M_ARADDR[i]          ),
                 .O_AOU_RX_AXI_M_ARLEN                      ( O_AOU_RX_AXI_M_ARLEN[i]           ),
@@ -1545,14 +1519,14 @@ module AOU_CORE #(
                 .O_AOU_RX_AXI_M_ARQOS                      ( O_AOU_RX_AXI_M_ARQOS[i]           ),
                 .O_AOU_RX_AXI_M_ARVALID                    ( O_AOU_RX_AXI_M_ARVALID[i]         ),
                 .I_AOU_RX_AXI_M_ARREADY                    ( I_AOU_RX_AXI_M_ARREADY[i]         ),
-                                                                                            
+
                 .I_AOU_TX_AXI_M_RID                        ( I_AOU_TX_AXI_M_RID[i]             ),
                 .I_AOU_TX_AXI_M_RDATA                      ( I_AOU_TX_AXI_M_RDATA[i][RP_AXI_DATA_WD[i]-1:0] ),
                 .I_AOU_TX_AXI_M_RRESP                      ( I_AOU_TX_AXI_M_RRESP[i]           ),
                 .I_AOU_TX_AXI_M_RLAST                      ( I_AOU_TX_AXI_M_RLAST[i]           ),
                 .I_AOU_TX_AXI_M_RVALID                     ( I_AOU_TX_AXI_M_RVALID[i]          ),
                 .O_AOU_TX_AXI_M_RREADY                     ( O_AOU_TX_AXI_M_RREADY[i]          ),
-                                                                                            
+
                 .O_AOU_RX_AXI_M_AWID                       ( O_AOU_RX_AXI_M_AWID[i]            ),
                 .O_AOU_RX_AXI_M_AWADDR                     ( O_AOU_RX_AXI_M_AWADDR[i]          ),
                 .O_AOU_RX_AXI_M_AWLEN                      ( O_AOU_RX_AXI_M_AWLEN[i]           ),
@@ -1564,29 +1538,29 @@ module AOU_CORE #(
                 .O_AOU_RX_AXI_M_AWQOS                      ( O_AOU_RX_AXI_M_AWQOS[i]           ),
                 .O_AOU_RX_AXI_M_AWVALID                    ( O_AOU_RX_AXI_M_AWVALID[i]         ),
                 .I_AOU_RX_AXI_M_AWREADY                    ( I_AOU_RX_AXI_M_AWREADY[i]         ),
-                                                                                            
+
                 .O_AOU_RX_AXI_M_WDATA                      ( O_AOU_RX_AXI_M_WDATA[i][RP_AXI_DATA_WD[i]-1:0] ),
                 .O_AOU_RX_AXI_M_WSTRB                      ( O_AOU_RX_AXI_M_WSTRB[i][RP_AXI_STRB_WD[i]-1:0] ),
                 .O_AOU_RX_AXI_M_WLAST                      ( O_AOU_RX_AXI_M_WLAST[i]           ),
                 .O_AOU_RX_AXI_M_WVALID                     ( O_AOU_RX_AXI_M_WVALID[i]          ),
                 .I_AOU_RX_AXI_M_WREADY                     ( I_AOU_RX_AXI_M_WREADY[i]          ),
-                
+
                 .I_AOU_TX_AXI_M_BID                        ( I_AOU_TX_AXI_M_BID[i]             ),
                 .I_AOU_TX_AXI_M_BRESP                      ( I_AOU_TX_AXI_M_BRESP[i]           ),
                 .I_AOU_TX_AXI_M_BVALID                     ( I_AOU_TX_AXI_M_BVALID[i]          ),
                 .O_AOU_TX_AXI_M_BREADY                     ( O_AOU_TX_AXI_M_BREADY[i]          ),
-                
+
                 .I_AOU_TX_AXI_S_ARID                       ( I_AOU_TX_AXI_S_ARID[i]            ),
                 .I_AOU_TX_AXI_S_ARVALID                    ( w_aou_tx_axi_s_arvalid[i]         ),
-                .I_AOU_TX_AXI_S_ARREADY                    ( O_AOU_TX_AXI_S_ARREADY[i]         ),    
+                .I_AOU_TX_AXI_S_ARREADY                    ( O_AOU_TX_AXI_S_ARREADY[i]         ),
                 .O_AOU_SLV_INFO_AR_HOLD_FLAG               ( w_aou_slv_info_ar_hold_flag[i]    ),
-                                                                                            
+
                 .I_AOU_RX_AXI_S_RID                        ( I_AOU_RX_AXI_S_RID[i]             ),
                 .I_AOU_RX_AXI_S_RLAST                      ( I_AOU_RX_AXI_S_RLAST[i]           ),
                 .I_AOU_RX_AXI_S_RVALID                     ( I_AOU_RX_AXI_S_RVALID[i]          ),
                 .I_AOU_RX_AXI_S_RREADY                     ( I_AOU_RX_AXI_S_RREADY[i]          ),
                 .O_AOU_RX_AXI_S_RVALID_BLOCKED             ( O_AOU_RX_AXI_S_RVALID_BLOCKED[i]  ),
-                
+
                 .I_AOU_TX_AXI_S_AWID                       ( I_AOU_TX_AXI_S_AWID[i]            ),
                 .I_AOU_TX_AXI_S_AWADDR                     ( I_AOU_TX_AXI_S_AWADDR[i]          ),
                 .I_AOU_TX_AXI_S_AWLEN                      ( I_AOU_TX_AXI_S_AWLEN[i]           ),
@@ -1598,117 +1572,117 @@ module AOU_CORE #(
                 .I_AOU_TX_AXI_S_AWQOS                      ( I_AOU_TX_AXI_S_AWQOS[i]           ),
                 .I_AOU_TX_AXI_S_AWVALID                    ( I_AOU_TX_AXI_S_AWVALID[i]         ),
                 .O_AOU_TX_AXI_S_AWREADY                    ( O_AOU_TX_AXI_S_AWREADY[i]         ),
-                                                                                            
+
                 .I_AOU_TX_AXI_S_WDATA                      ( I_AOU_TX_AXI_S_WDATA[i][RP_AXI_DATA_WD[i]-1:0] ),
                 .I_AOU_TX_AXI_S_WSTRB                      ( I_AOU_TX_AXI_S_WSTRB[i][RP_AXI_STRB_WD[i]-1:0] ),
                 .I_AOU_TX_AXI_S_WLAST                      ( I_AOU_TX_AXI_S_WLAST[i]           ),
                 .I_AOU_TX_AXI_S_WVALID                     ( I_AOU_TX_AXI_S_WVALID[i]          ),
                 .O_AOU_TX_AXI_S_WREADY                     ( O_AOU_TX_AXI_S_WREADY[i]          ),
-                                                                                            
+
                 .O_AOU_RX_AXI_S_BID                        ( O_AOU_RX_AXI_S_BID[i]             ),
                 .O_AOU_RX_AXI_S_BRESP                      ( O_AOU_RX_AXI_S_BRESP[i]           ),
                 .O_AOU_RX_AXI_S_BVALID                     ( O_AOU_RX_AXI_S_BVALID[i]          ),
                 .I_AOU_RX_AXI_S_BREADY                     ( I_AOU_RX_AXI_S_BREADY[i]          ),
-                
+
                 .I_AOU_RX_WLAST_GEN_AWID                   ( I_AOU_RX_WLAST_GEN_AWID[i]        ),
                 .I_AOU_RX_WLAST_GEN_AWADDR                 ( I_AOU_RX_WLAST_GEN_AWADDR[i]      ),
                 .I_AOU_RX_WLAST_GEN_AWLEN                  ( I_AOU_RX_WLAST_GEN_AWLEN[i]       ),
-                .I_AOU_RX_WLAST_GEN_AWSIZE                 ( I_AOU_RX_WLAST_GEN_AWSIZE[i]      ),      
-                .I_AOU_RX_WLAST_GEN_AWLOCK                 ( I_AOU_RX_WLAST_GEN_AWLOCK[i]      ),      
-                .I_AOU_RX_WLAST_GEN_AWCACHE                ( I_AOU_RX_WLAST_GEN_AWCACHE[i]     ),     
-                .I_AOU_RX_WLAST_GEN_AWPROT                 ( I_AOU_RX_WLAST_GEN_AWPROT[i]      ),    
-                .I_AOU_RX_WLAST_GEN_AWQOS                  ( I_AOU_RX_WLAST_GEN_AWQOS[i]       ),     
-                .I_AOU_RX_WLAST_GEN_AWVALID                ( I_AOU_RX_WLAST_GEN_AWVALID[i]     ),       
-                .O_AOU_RX_WLAST_GEN_AWREADY                ( O_AOU_RX_WLAST_GEN_AWREADY[i]     ),     
-                                                                                            
+                .I_AOU_RX_WLAST_GEN_AWSIZE                 ( I_AOU_RX_WLAST_GEN_AWSIZE[i]      ),
+                .I_AOU_RX_WLAST_GEN_AWLOCK                 ( I_AOU_RX_WLAST_GEN_AWLOCK[i]      ),
+                .I_AOU_RX_WLAST_GEN_AWCACHE                ( I_AOU_RX_WLAST_GEN_AWCACHE[i]     ),
+                .I_AOU_RX_WLAST_GEN_AWPROT                 ( I_AOU_RX_WLAST_GEN_AWPROT[i]      ),
+                .I_AOU_RX_WLAST_GEN_AWQOS                  ( I_AOU_RX_WLAST_GEN_AWQOS[i]       ),
+                .I_AOU_RX_WLAST_GEN_AWVALID                ( I_AOU_RX_WLAST_GEN_AWVALID[i]     ),
+                .O_AOU_RX_WLAST_GEN_AWREADY                ( O_AOU_RX_WLAST_GEN_AWREADY[i]     ),
+
                 .I_AOU_RX_WLAST_GEN_WDLENGTH               ( I_AOU_RX_WLAST_GEN_WDLENGTH[i]    ),
-                .I_AOU_RX_WLAST_GEN_WDATA                  ( I_AOU_RX_WLAST_GEN_WDATA[i]       ),    
-                .I_AOU_RX_WLAST_GEN_WSTRB                  ( I_AOU_RX_WLAST_GEN_WSTRB[i]       ),      
+                .I_AOU_RX_WLAST_GEN_WDATA                  ( I_AOU_RX_WLAST_GEN_WDATA[i]       ),
+                .I_AOU_RX_WLAST_GEN_WSTRB                  ( I_AOU_RX_WLAST_GEN_WSTRB[i]       ),
                 .I_AOU_RX_WLAST_GEN_WVALID                 ( I_AOU_RX_WLAST_GEN_WVALID[i]      ),
                 .O_AOU_RX_WLAST_GEN_WREADY                 ( O_AOU_RX_WLAST_GEN_WREADY[i]      ),
-                                                                                            
-                .I_AOU_RX_AXI_MM_ARID                      ( I_AOU_RX_AXI_MM_ARID[i]           ),        
+
+                .I_AOU_RX_AXI_MM_ARID                      ( I_AOU_RX_AXI_MM_ARID[i]           ),
                 .I_AOU_RX_AXI_MM_ARADDR                    ( I_AOU_RX_AXI_MM_ARADDR[i]         ),
-                .I_AOU_RX_AXI_MM_ARLEN                     ( I_AOU_RX_AXI_MM_ARLEN[i]          ),      
-                .I_AOU_RX_AXI_MM_ARSIZE                    ( I_AOU_RX_AXI_MM_ARSIZE[i]         ),          
-                .I_AOU_RX_AXI_MM_ARLOCK                    ( I_AOU_RX_AXI_MM_ARLOCK[i]         ),      
-                .I_AOU_RX_AXI_MM_ARCACHE                   ( I_AOU_RX_AXI_MM_ARCACHE[i]        ),     
-                .I_AOU_RX_AXI_MM_ARPROT                    ( I_AOU_RX_AXI_MM_ARPROT[i]         ),      
-                .I_AOU_RX_AXI_MM_ARQOS                     ( I_AOU_RX_AXI_MM_ARQOS[i]          ),       
-                .I_AOU_RX_AXI_MM_ARVALID                   ( I_AOU_RX_AXI_MM_ARVALID[i]        ),     
+                .I_AOU_RX_AXI_MM_ARLEN                     ( I_AOU_RX_AXI_MM_ARLEN[i]          ),
+                .I_AOU_RX_AXI_MM_ARSIZE                    ( I_AOU_RX_AXI_MM_ARSIZE[i]         ),
+                .I_AOU_RX_AXI_MM_ARLOCK                    ( I_AOU_RX_AXI_MM_ARLOCK[i]         ),
+                .I_AOU_RX_AXI_MM_ARCACHE                   ( I_AOU_RX_AXI_MM_ARCACHE[i]        ),
+                .I_AOU_RX_AXI_MM_ARPROT                    ( I_AOU_RX_AXI_MM_ARPROT[i]         ),
+                .I_AOU_RX_AXI_MM_ARQOS                     ( I_AOU_RX_AXI_MM_ARQOS[i]          ),
+                .I_AOU_RX_AXI_MM_ARVALID                   ( I_AOU_RX_AXI_MM_ARVALID[i]        ),
                 .O_AOU_RX_AXI_MM_ARREADY                   ( O_AOU_RX_AXI_MM_ARREADY[i]        ),
-                
+
                 .I_EARLY_BRESP_CTRL_BID                    ( I_EARLY_BRESP_CTRL_BID[i]         ),
                 .I_EARLY_BRESP_CTRL_BRESP                  ( I_EARLY_BRESP_CTRL_BRESP[i]       ),
                 .I_EARLY_BRESP_CTRL_BVALID                 ( I_EARLY_BRESP_CTRL_BVALID[i]      ),
                 .O_EARLY_BRESP_CTRL_BREADY                 ( O_EARLY_BRESP_CTRL_BREADY[i]      ),
-                
-                .O_EARLY_BRESP_CTRL_AWID                   ( w_early_bresp_ctrl_awid[i]        ),    
-                .O_EARLY_BRESP_CTRL_AWADDR                 ( w_early_bresp_ctrl_awaddr[i]      ),    
-                .O_EARLY_BRESP_CTRL_AWLEN                  ( w_early_bresp_ctrl_awlen[i]       ),    
-                .O_EARLY_BRESP_CTRL_AWSIZE                 ( w_early_bresp_ctrl_awsize[i]      ),    
-                .O_EARLY_BRESP_CTRL_AWBURST                ( w_early_bresp_ctrl_awburst[i]     ),    
-                .O_EARLY_BRESP_CTRL_AWLOCK                 ( w_early_bresp_ctrl_awlock[i]      ),    
-                .O_EARLY_BRESP_CTRL_AWCACHE                ( w_early_bresp_ctrl_awcache[i]     ),    
-                .O_EARLY_BRESP_CTRL_AWPROT                 ( w_early_bresp_ctrl_awprot[i]      ),    
-                .O_EARLY_BRESP_CTRL_AWQOS                  ( w_early_bresp_ctrl_awqos[i]       ),    
-                .O_EARLY_BRESP_CTRL_AWVALID                ( w_early_bresp_ctrl_awvalid[i]     ),    
-                .I_EARLY_BRESP_CTRL_AWREADY                ( w_early_bresp_ctrl_awready[i]     ),        
-                                                                  
-                .O_EARLY_BRESP_CTRL_WDATA                  ( w_early_bresp_ctrl_wdata[i][RP_AXI_DATA_WD[i]-1:0] ), 
+
+                .O_EARLY_BRESP_CTRL_AWID                   ( w_early_bresp_ctrl_awid[i]        ),
+                .O_EARLY_BRESP_CTRL_AWADDR                 ( w_early_bresp_ctrl_awaddr[i]      ),
+                .O_EARLY_BRESP_CTRL_AWLEN                  ( w_early_bresp_ctrl_awlen[i]       ),
+                .O_EARLY_BRESP_CTRL_AWSIZE                 ( w_early_bresp_ctrl_awsize[i]      ),
+                .O_EARLY_BRESP_CTRL_AWBURST                ( w_early_bresp_ctrl_awburst[i]     ),
+                .O_EARLY_BRESP_CTRL_AWLOCK                 ( w_early_bresp_ctrl_awlock[i]      ),
+                .O_EARLY_BRESP_CTRL_AWCACHE                ( w_early_bresp_ctrl_awcache[i]     ),
+                .O_EARLY_BRESP_CTRL_AWPROT                 ( w_early_bresp_ctrl_awprot[i]      ),
+                .O_EARLY_BRESP_CTRL_AWQOS                  ( w_early_bresp_ctrl_awqos[i]       ),
+                .O_EARLY_BRESP_CTRL_AWVALID                ( w_early_bresp_ctrl_awvalid[i]     ),
+                .I_EARLY_BRESP_CTRL_AWREADY                ( w_early_bresp_ctrl_awready[i]     ),
+
+                .O_EARLY_BRESP_CTRL_WDATA                  ( w_early_bresp_ctrl_wdata[i][RP_AXI_DATA_WD[i]-1:0] ),
                 .O_EARLY_BRESP_CTRL_WSTRB                  ( w_early_bresp_ctrl_wstrb[i][RP_AXI_STRB_WD[i]-1:0] ),
-                .O_EARLY_BRESP_CTRL_WLAST                  ( w_early_bresp_ctrl_wlast[i]       ), 
-                .O_EARLY_BRESP_CTRL_WVALID                 ( w_early_bresp_ctrl_wvalid[i]      ), 
+                .O_EARLY_BRESP_CTRL_WLAST                  ( w_early_bresp_ctrl_wlast[i]       ),
+                .O_EARLY_BRESP_CTRL_WVALID                 ( w_early_bresp_ctrl_wvalid[i]      ),
                 .I_EARLY_BRESP_CTRL_WREADY                 ( w_early_bresp_ctrl_wready[i]      ),
-                
-                .O_AOU_TX_AXI_BID_256                      ( w_aou_tx_axi_mm_bid_256[i]        ), 
-                .O_AOU_TX_AXI_BRESP_256                    ( w_aou_tx_axi_mm_bresp_256[i]      ), 
-                .O_AOU_TX_AXI_BVALID_256                   ( w_aou_tx_axi_mm_bvalid_256[i]     ), 
-                .I_AOU_TX_AXI_BREADY_256                   ( w_aou_tx_axi_mm_bready_256[i]     ), 
-                                                                                            
-                .O_AOU_TX_AXI_BID_512                      ( w_aou_tx_axi_mm_bid_512[i]        ), 
-                .O_AOU_TX_AXI_BRESP_512                    ( w_aou_tx_axi_mm_bresp_512[i]      ), 
-                .O_AOU_TX_AXI_BVALID_512                   ( w_aou_tx_axi_mm_bvalid_512[i]     ), 
-                .I_AOU_TX_AXI_BREADY_512                   ( w_aou_tx_axi_mm_bready_512[i]     ), 
-                                                                                            
-                .O_AOU_TX_AXI_BID_1024                     ( w_aou_tx_axi_mm_bid_1024[i]       ), 
-                .O_AOU_TX_AXI_BRESP_1024                   ( w_aou_tx_axi_mm_bresp_1024[i]     ), 
-                .O_AOU_TX_AXI_BVALID_1024                  ( w_aou_tx_axi_mm_bvalid_1024[i]    ), 
-                .I_AOU_TX_AXI_BREADY_1024                  ( w_aou_tx_axi_mm_bready_1024[i]    ), 
-                
-                .O_AOU_TX_AXI_RID                          ( w_aou_tx_axi_mm_rid[i]            ), 
-                .O_AOU_TX_AXI_RDLEN                        ( w_aou_tx_axi_mm_rdlen[i]          ), 
-                .O_AOU_TX_AXI_RDATA                        ( w_aou_tx_axi_mm_rdata[i]          ), 
-                .O_AOU_TX_AXI_RRESP                        ( w_aou_tx_axi_mm_rresp[i]          ), 
-                .O_AOU_TX_AXI_RLAST                        ( w_aou_tx_axi_mm_rlast[i]          ), 
-                .O_AOU_TX_AXI_RVALID                       ( w_aou_tx_axi_mm_rvalid[i]         ), 
-                .I_AOU_TX_AXI_RREADY                       ( w_aou_tx_axi_mm_rready[i]         ), 
-                
-                .I_AXI_SPLIT_TR_MAX_AWBURSTLEN             ( w_axi_split_tr_max_awburstlen[i]  ), 
-                .I_AXI_SPLIT_TR_MAX_ARBURSTLEN             ( w_axi_split_tr_max_arburstlen[i]  ), 
-                
+
+                .O_AOU_TX_AXI_BID_256                      ( w_aou_tx_axi_mm_bid_256[i]        ),
+                .O_AOU_TX_AXI_BRESP_256                    ( w_aou_tx_axi_mm_bresp_256[i]      ),
+                .O_AOU_TX_AXI_BVALID_256                   ( w_aou_tx_axi_mm_bvalid_256[i]     ),
+                .I_AOU_TX_AXI_BREADY_256                   ( w_aou_tx_axi_mm_bready_256[i]     ),
+
+                .O_AOU_TX_AXI_BID_512                      ( w_aou_tx_axi_mm_bid_512[i]        ),
+                .O_AOU_TX_AXI_BRESP_512                    ( w_aou_tx_axi_mm_bresp_512[i]      ),
+                .O_AOU_TX_AXI_BVALID_512                   ( w_aou_tx_axi_mm_bvalid_512[i]     ),
+                .I_AOU_TX_AXI_BREADY_512                   ( w_aou_tx_axi_mm_bready_512[i]     ),
+
+                .O_AOU_TX_AXI_BID_1024                     ( w_aou_tx_axi_mm_bid_1024[i]       ),
+                .O_AOU_TX_AXI_BRESP_1024                   ( w_aou_tx_axi_mm_bresp_1024[i]     ),
+                .O_AOU_TX_AXI_BVALID_1024                  ( w_aou_tx_axi_mm_bvalid_1024[i]    ),
+                .I_AOU_TX_AXI_BREADY_1024                  ( w_aou_tx_axi_mm_bready_1024[i]    ),
+
+                .O_AOU_TX_AXI_RID                          ( w_aou_tx_axi_mm_rid[i]            ),
+                .O_AOU_TX_AXI_RDLEN                        ( w_aou_tx_axi_mm_rdlen[i]          ),
+                .O_AOU_TX_AXI_RDATA                        ( w_aou_tx_axi_mm_rdata[i]          ),
+                .O_AOU_TX_AXI_RRESP                        ( w_aou_tx_axi_mm_rresp[i]          ),
+                .O_AOU_TX_AXI_RLAST                        ( w_aou_tx_axi_mm_rlast[i]          ),
+                .O_AOU_TX_AXI_RVALID                       ( w_aou_tx_axi_mm_rvalid[i]         ),
+                .I_AOU_TX_AXI_RREADY                       ( w_aou_tx_axi_mm_rready[i]         ),
+
+                .I_AXI_SPLIT_TR_MAX_AWBURSTLEN             ( w_axi_split_tr_max_awburstlen[i]  ),
+                .I_AXI_SPLIT_TR_MAX_ARBURSTLEN             ( w_axi_split_tr_max_arburstlen[i]  ),
+
                 .I_AXI_SLV_ID_MISMATCH_EN                  ( w_axi_slv_id_mismatch_en[i]       ),
 
                 .O_ERROR_INFO_SPLIT_BID_MISMATCH_INFO      ( w_err_info_split_bid_mismatch[i]  ),
                 .O_ERROR_INFO_RID_MISMATCH_INFO            ( w_err_info_rid_mismatch[i]        ),
                 .O_ERROR_INFO_SPLIT_BID_MISMATCH_ERR_SET   ( w_err_split_bid_mismatch_set[i]   ),
                 .O_ERROR_INFO_RID_MISMATCH_ERR_SET         ( w_err_rid_mismatch_set[i]         ),
-                
+
                 .O_EARLY_BRESP_DONE                        ( w_early_bresp_done[i]             ),
                 .O_EARLY_BRESP_ERR_SET                     ( w_bresp_err[i]                    ),
                 .O_EARLY_BRESP_ERR_TYPE                    ( w_bresp_err_type[i]               ),
                 .O_EARLY_BRESP_ERR_ID                      ( w_bresp_err_id[i]                 ),
                 .I_EARLY_BRESP_EN                          ( w_early_bresp_en[i]               ),
-                
+
                 .I_DEBUG_ERROR_INFO_UPPER_ADDR             ( w_debug_error_info_upper_addr[i]  ),
                 .I_DEBUG_ERROR_INFO_LOWER_ADDR             ( w_debug_error_info_lower_addr[i]  ),
                 .I_DEBUG_ERR_ACCESS_ENABLE                 ( w_debug_error_info_access_enable[i]),
-                
+
                 .I_AXI_AGGREGATOR_EN                       ( w_axi_aggregator_en[i]            ),
-                
-                .O_AXI_SLV_BID_MISMATCH_INFO               ( w_axi_slv_bid_mismatch_info[i]    ),    
-                .O_AXI_SLV_RID_MISMATCH_INFO               ( w_axi_slv_rid_mismatch_info[i]    ), 
-                .O_AXI_SLV_BID_MISMATCH_ERR_SET            ( w_axi_slv_bid_mismatch_err_set[i] ),    
+
+                .O_AXI_SLV_BID_MISMATCH_INFO               ( w_axi_slv_bid_mismatch_info[i]    ),
+                .O_AXI_SLV_RID_MISMATCH_INFO               ( w_axi_slv_rid_mismatch_info[i]    ),
+                .O_AXI_SLV_BID_MISMATCH_ERR_SET            ( w_axi_slv_bid_mismatch_err_set[i] ),
                 .O_AXI_SLV_RID_MISMATCH_ERR_SET            ( w_axi_slv_rid_mismatch_err_set[i] ),
 
                 .O_SLV_TR_COMPLETE                         ( w_slv_tr_complete[i]              ),
@@ -1720,26 +1694,26 @@ module AOU_CORE #(
     genvar j;
     generate
         for(j = RP_COUNT ; j < 4; j++) begin: gen_unused_sfr_tie
-            assign  w_err_info_split_bid_mismatch[j]  = 1'b0; 
-            assign  w_err_info_rid_mismatch[j]        = 1'b0; 
-            assign  w_err_split_bid_mismatch_set[j]   = 1'b0; 
-            assign  w_err_rid_mismatch_set[j]         = 1'b0; 
-              
-            assign  w_early_bresp_done[j]             = 1'b0; 
-            assign  w_bresp_err[j]                    = 1'b0; 
-            assign  w_bresp_err_type[j]               = 1'b0; 
-            assign  w_bresp_err_id[j]                 = 1'b0; 
-              
-            assign  w_axi_slv_bid_mismatch_info[j]    = 1'b0; 
-            assign  w_axi_slv_rid_mismatch_info[j]    = 1'b0; 
-            assign  w_axi_slv_bid_mismatch_err_set[j] = 1'b0; 
-            assign  w_axi_slv_rid_mismatch_err_set[j] = 1'b0; 
-             
-            assign  w_slv_tr_complete[j]              = 1'b1; 
+            assign  w_err_info_split_bid_mismatch[j]  = 1'b0;
+            assign  w_err_info_rid_mismatch[j]        = 1'b0;
+            assign  w_err_split_bid_mismatch_set[j]   = 1'b0;
+            assign  w_err_rid_mismatch_set[j]         = 1'b0;
+
+            assign  w_early_bresp_done[j]             = 1'b0;
+            assign  w_bresp_err[j]                    = 1'b0;
+            assign  w_bresp_err_type[j]               = 1'b0;
+            assign  w_bresp_err_id[j]                 = 1'b0;
+
+            assign  w_axi_slv_bid_mismatch_info[j]    = 1'b0;
+            assign  w_axi_slv_rid_mismatch_info[j]    = 1'b0;
+            assign  w_axi_slv_bid_mismatch_err_set[j] = 1'b0;
+            assign  w_axi_slv_rid_mismatch_err_set[j] = 1'b0;
+
+            assign  w_slv_tr_complete[j]              = 1'b1;
             assign  w_mst_tr_complete[j]              = 1'b1;
-        end               
-    endgenerate 
-    
+        end
+    endgenerate
+
     assign O_SLV_TR_COMPLETE = &w_slv_tr_complete;
     assign O_MST_TR_COMPLETE = &w_mst_tr_complete;
 

--- a/RTL/AOU_CORE_TOP.sv
+++ b/RTL/AOU_CORE_TOP.sv
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -29,55 +30,68 @@ module AOU_CORE_TOP
 import packet_def_pkg::*;
 #(
     parameter   RP_COUNT                    = 1,
-`ifdef FDI_128B
+
+    // FDI configuration selector. Single integer that picks the FDI data
+    // bus widths for both PHYs and (in two-PHY builds) the per-PHY pairing.
+    //
+    //   FDI_CFG_SP_32B      -> WD0=256,  WD1=512   (single PHY 32B)
+    //   FDI_CFG_SP_64B      -> WD0=512,  WD1=512   (single PHY 64B)
+    //   FDI_CFG_SP_128B     -> WD0=1024, WD1=1024  (single PHY 128B)
+    //   FDI_CFG_TP_32B_64B  -> WD0=256,  WD1=512   (two PHY, requires
+    //                                                +define+TWO_PHY)
+    //   FDI_CFG_TP_64B_128B -> WD0=512,  WD1=1024  (two PHY, requires
+    //                                                +define+TWO_PHY)
+    //
+    // The internal FDI_IF_WD0 / FDI_IF_WD1 widths are derived as localparams
+    // below and forwarded to the AOU_CORE submodule. Default matches the
+    // legacy +define+FDI_32B single-PHY configuration so that existing
+    // builds remain valid when the FDI_*B defines are removed. Consistency
+    // between FDI_CONFIG and +define+TWO_PHY is the integrator's
+    // responsibility (use an FDI_CFG_TP_* value if and only if
+    // +define+TWO_PHY is set); no in-RTL elaboration check is added.
+    parameter int FDI_CONFIG                = FDI_CFG_SP_32B,
+
+    // Derived FDI data bus widths (bits). Single source of truth for both
+    // top-level port sizing and the FIFO-depth ternaries below. Forwarded to
+    // AOU_CORE via the same .FDI_IF_WD0 / .FDI_IF_WD1 parameters that the
+    // internal hierarchy already consumes (no internal-module changes).
+    localparam int FDI_IF_WD0 = (FDI_CONFIG == FDI_CFG_SP_32B     ) ? 256  :
+                                (FDI_CONFIG == FDI_CFG_SP_64B     ) ? 512  :
+                                (FDI_CONFIG == FDI_CFG_SP_128B    ) ? 1024 :
+                                (FDI_CONFIG == FDI_CFG_TP_32B_64B ) ? 256  :
+                                (FDI_CONFIG == FDI_CFG_TP_64B_128B) ? 512  : 256,
+    localparam int FDI_IF_WD1 = (FDI_CONFIG == FDI_CFG_SP_32B     ) ? 512  :
+                                (FDI_CONFIG == FDI_CFG_SP_64B     ) ? 512  :
+                                (FDI_CONFIG == FDI_CFG_SP_128B    ) ? 1024 :
+                                (FDI_CONFIG == FDI_CFG_TP_32B_64B ) ? 512  :
+                                (FDI_CONFIG == FDI_CFG_TP_64B_128B) ? 1024 : 512,
+
+    // FIFO depths default to 140 for 1024b (128B) FDI data paths, 88 otherwise.
+    // Matches the original +define+FDI_128B branch which applied to both
+    // single-PHY (FDI_IF_WD0 == 1024) and two-PHY (FDI_IF_WD1 == 1024) cases.
     parameter   RP0_RX_AW_FIFO_DEPTH        = 44,
     parameter   RP0_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP0_RX_W_FIFO_DEPTH         = 140,
-    parameter   RP0_RX_R_FIFO_DEPTH         = 140,
+    parameter   RP0_RX_W_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
+    parameter   RP0_RX_R_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
     parameter   RP0_RX_B_FIFO_DEPTH         = 44,
 
     parameter   RP1_RX_AW_FIFO_DEPTH        = 44,
     parameter   RP1_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP1_RX_W_FIFO_DEPTH         = 140,
-    parameter   RP1_RX_R_FIFO_DEPTH         = 140,
+    parameter   RP1_RX_W_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
+    parameter   RP1_RX_R_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
     parameter   RP1_RX_B_FIFO_DEPTH         = 44,
 
     parameter   RP2_RX_AW_FIFO_DEPTH        = 44,
     parameter   RP2_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP2_RX_W_FIFO_DEPTH         = 140,
-    parameter   RP2_RX_R_FIFO_DEPTH         = 140,
+    parameter   RP2_RX_W_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
+    parameter   RP2_RX_R_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
     parameter   RP2_RX_B_FIFO_DEPTH         = 44,
 
     parameter   RP3_RX_AW_FIFO_DEPTH        = 44,
     parameter   RP3_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP3_RX_W_FIFO_DEPTH         = 140,
-    parameter   RP3_RX_R_FIFO_DEPTH         = 140,
+    parameter   RP3_RX_W_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
+    parameter   RP3_RX_R_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
     parameter   RP3_RX_B_FIFO_DEPTH         = 44,
-`else 
-    parameter   RP0_RX_AW_FIFO_DEPTH        = 44,
-    parameter   RP0_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP0_RX_W_FIFO_DEPTH         = 88,
-    parameter   RP0_RX_R_FIFO_DEPTH         = 88,
-    parameter   RP0_RX_B_FIFO_DEPTH         = 44,
-
-    parameter   RP1_RX_AW_FIFO_DEPTH        = 44,
-    parameter   RP1_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP1_RX_W_FIFO_DEPTH         = 88,
-    parameter   RP1_RX_R_FIFO_DEPTH         = 88,
-    parameter   RP1_RX_B_FIFO_DEPTH         = 44,
-
-    parameter   RP2_RX_AW_FIFO_DEPTH        = 44,
-    parameter   RP2_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP2_RX_W_FIFO_DEPTH         = 88,
-    parameter   RP2_RX_R_FIFO_DEPTH         = 88,
-    parameter   RP2_RX_B_FIFO_DEPTH         = 44,
-
-    parameter   RP3_RX_AW_FIFO_DEPTH        = 44,
-    parameter   RP3_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP3_RX_W_FIFO_DEPTH         = 88,
-    parameter   RP3_RX_R_FIFO_DEPTH         = 88,
-    parameter   RP3_RX_B_FIFO_DEPTH         = 44,
-`endif
 
     parameter   RX_AW_FIFO_RS_EN            = 1,
     parameter   RX_AR_FIFO_RS_EN            = 1,
@@ -110,30 +124,6 @@ import packet_def_pkg::*;
 
     localparam  AXI_MAX_STRB_WD             = AXI_PEER_DIE_MAX_DATA_WD / 8,
 
-
-`ifdef TWO_PHY
-
-    `ifdef FDI_32B
-        localparam int FDI_IF_WD0 = 256,
-        localparam int FDI_IF_WD1 = 512,
-    `elsif FDI_128B
-        localparam int FDI_IF_WD0 = 512,
-        localparam int FDI_IF_WD1 = 1024,
-    `else
-    `endif
-
-`else
-    localparam int FDI_IF_WD1 = 512,
-    `ifdef FDI_32B
-        localparam int FDI_IF_WD0 = 256,
-    `elsif FDI_64B
-        localparam int FDI_IF_WD0 = 512,
-    `elsif FDI_128B
-        localparam int FDI_IF_WD0 = 1024,
-    `else
-    `endif
-`endif
-
     localparam int unsigned RP_AXI_DATA_WD[4]   = '{
         RP0_AXI_DATA_WD,
         RP1_AXI_DATA_WD,
@@ -147,7 +137,7 @@ import packet_def_pkg::*;
         RP2_RX_AW_FIFO_DEPTH,
         RP3_RX_AW_FIFO_DEPTH
     },
-    
+
     localparam int unsigned RP_AR_FIFO_DEPTH[4] = '{
         RP0_RX_AR_FIFO_DEPTH,
         RP1_RX_AR_FIFO_DEPTH,
@@ -161,7 +151,7 @@ import packet_def_pkg::*;
         RP2_RX_R_FIFO_DEPTH,
         RP3_RX_R_FIFO_DEPTH
     },
-    
+
     localparam int unsigned RP_W_FIFO_DEPTH[4] = '{
         RP0_RX_W_FIFO_DEPTH,
         RP1_RX_W_FIFO_DEPTH,
@@ -175,7 +165,7 @@ import packet_def_pkg::*;
         RP2_RX_B_FIFO_DEPTH,
         RP3_RX_B_FIFO_DEPTH
     }
-    
+
 )
 (
     input                                           I_CLK,
@@ -283,7 +273,7 @@ import packet_def_pkg::*;
 
     //Interface for AOU_RX_CORE FDI
     input                                                   I_FDI_PL_0_VALID,
-    input   [FDI_IF_WD0-1: 0]                               I_FDI_PL_0_DATA,            
+    input   [FDI_IF_WD0-1: 0]                               I_FDI_PL_0_DATA,
     input                                                   I_FDI_PL_0_FLIT_CANCEL,
 
     //Interface for AOU_TX_CORE FDI
@@ -299,7 +289,7 @@ import packet_def_pkg::*;
     input                                                   I_PHY_TYPE,
 
     input                                                   I_FDI_PL_1_VALID,
-    input   [FDI_IF_WD1-1: 0]                               I_FDI_PL_1_DATA,            
+    input   [FDI_IF_WD1-1: 0]                               I_FDI_PL_1_DATA,
     input                                                   I_FDI_PL_1_FLIT_CANCEL,
 
     input                                                   I_FDI_PL_1_TRDY,
@@ -317,7 +307,7 @@ import packet_def_pkg::*;
     output                                          INT_MI0_ID_MISMATCH,
 
     output                                          INT_EARLY_RESP_ERR,
-                                                    
+
     output                                          INT_ACTIVATE_START,
     output                                          INT_DEACTIVATE_START,
 
@@ -333,22 +323,19 @@ import packet_def_pkg::*;
     input                                           TIEL_DFT_MODESCAN
 );
 //----------------------------------------------------------------------------
-`ifdef TWO_PHY
-    localparam  PHY_TYPE                    = (FDI_IF_WD1 == 32*8)  ? 0:
-                                              (FDI_IF_WD1 == 64*8)  ? 1:
-                                              (FDI_IF_WD1 == 128*8) ? 2: 0;
-    localparam  PHASE_CNT                   = 256*8/FDI_IF_WD1;
-`elsif FDI_32B
-    localparam  PHY_TYPE                    = (FDI_IF_WD1 == 32*8)  ? 0:
-                                              (FDI_IF_WD1 == 64*8)  ? 1:
-                                              (FDI_IF_WD1 == 128*8) ? 2: 0;
-    localparam  PHASE_CNT                   = 256*8/FDI_IF_WD1;
-`else 
-    localparam  PHY_TYPE                    = (FDI_IF_WD0 == 32*8)  ? 0:
-                                              (FDI_IF_WD0 == 64*8)  ? 1:
-                                              (FDI_IF_WD0 == 128*8) ? 2: 0;
-    localparam  PHASE_CNT                   = 256*8/FDI_IF_WD0;
-`endif
+    // Active FDI width for RX decode and PHY classification.
+    // In both TWO_PHY and single-PHY configurations the relevant width is
+    // max(FDI_IF_WD0, FDI_IF_WD1). This matches the original ifdef branches:
+    //   TWO_PHY+FDI_32B   -> max(256,512)  = 512
+    //   TWO_PHY+FDI_128B  -> max(512,1024) = 1024
+    //   SP+FDI_32B        -> max(256,512)  = 512
+    //   SP+FDI_64B        -> max(512,512)  = 512
+    //   SP+FDI_128B       -> max(1024,512) = 1024
+    localparam  FDI_ACTIVE_WD               = (FDI_IF_WD0 > FDI_IF_WD1) ? FDI_IF_WD0 : FDI_IF_WD1;
+    localparam  PHY_TYPE                    = (FDI_ACTIVE_WD == 32*8)  ? 0:
+                                              (FDI_ACTIVE_WD == 64*8)  ? 1:
+                                              (FDI_ACTIVE_WD == 128*8) ? 2: 0;
+    localparam  PHASE_CNT                   = 256*8/FDI_ACTIVE_WD;
 
     localparam  DEC_MULTI                   = (PHY_TYPE == 0) ? 1 : 4/PHASE_CNT;
 
@@ -365,7 +352,7 @@ import packet_def_pkg::*;
     logic  [APB_ADDR_WD-1:0]                w_aou_apb_si0_paddr      ;
     logic                                   w_aou_apb_si0_pwrite     ;
     logic  [APB_DATA_WD-1:0]                w_aou_apb_si0_pwdata     ;
-    
+
     logic  [APB_DATA_WD-1:0]                w_aou_apb_si0_prdata     ;
     logic                                   w_aou_apb_si0_pready     ;
     logic                                   w_aou_apb_si0_pslverr    ;
@@ -381,12 +368,12 @@ import packet_def_pkg::*;
     logic    [RP_COUNT-1:0][3:0]            w_aou_rx_wlast_gen_awqos        ;
     logic    [RP_COUNT-1:0]                 w_aou_rx_wlast_gen_awvalid      ;
     logic    [RP_COUNT-1:0]                 w_aou_rx_wlast_gen_awready      ;
-    
+
     logic    [RP_COUNT-1:0][1024-1:0]       w_aou_rx_wlast_gen_wdata        ;
     logic    [RP_COUNT-1:0][128-1:0]        w_aou_rx_wlast_gen_wstrb        ;
     logic    [RP_COUNT-1:0]                 w_aou_rx_wlast_gen_wvalid       ;
     logic    [RP_COUNT-1:0]                 w_aou_rx_wlast_gen_wready       ;
-    
+
     logic    [RP_COUNT-1:0][1:0]            w_aou_rx_wlast_gen_wdlength     ;
     logic    [RP_COUNT-1:0]                 w_aou_rx_wlast_gen_wdataf       ;
     logic    [RP_COUNT-1:0][1:0]            w_aou_rx_axi_s_rdlength         ;
@@ -407,40 +394,40 @@ import packet_def_pkg::*;
     logic   [RP_COUNT-1:0][2:0]             w_aou_rx_axi_mm_arprot          ;
     logic   [RP_COUNT-1:0][3:0]             w_aou_rx_axi_mm_arqos           ;
     logic   [RP_COUNT-1:0]                  w_aou_rx_axi_mm_arvalid         ;
-    logic   [RP_COUNT-1:0]                  w_aou_rx_axi_mm_arready         ; 
+    logic   [RP_COUNT-1:0]                  w_aou_rx_axi_mm_arready         ;
 
 //----------------------------------------------------------------------------
-    logic                                   w_aou_rp0_aw_fifo_parity_error      ; 
-    logic                                   w_aou_rp0_w_fifo_parity_error       ;    
-    logic                                   w_aou_rp0_ar_fifo_parity_error      ;      
-    logic                                   w_aou_rp0_r_fifo_parity_error       ;     
-    logic                                   w_aou_rp0_b_fifo_parity_error       ;     
+    logic                                   w_aou_rp0_aw_fifo_parity_error      ;
+    logic                                   w_aou_rp0_w_fifo_parity_error       ;
+    logic                                   w_aou_rp0_ar_fifo_parity_error      ;
+    logic                                   w_aou_rp0_r_fifo_parity_error       ;
+    logic                                   w_aou_rp0_b_fifo_parity_error       ;
 //----------------------------------------------------------------------------
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][MAX_REQ_COUNT -1:0][AW_AR_FIFO_WIDTH-1:0]       w_rd_req_fifo_sdata;
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][MAX_REQ_COUNT -1:0]                             w_rd_req_fifo_svalid;
-    
+
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][MAX_REQ_COUNT -1:0][AW_AR_FIFO_WIDTH-1:0]       w_wr_req_fifo_sdata;
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][MAX_REQ_COUNT -1:0]                             w_wr_req_fifo_svalid;
-    
+
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0] w_wr_data_fifo_sdata;
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0][AXI_MAX_STRB_WD -1:0]         w_wr_data_fifo_sdata_strb;
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0]                               w_wr_data_fifo_sdata_wdataf;
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0][1:0]                          w_wr_data_fifo_sdlen;
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0]                               w_wr_data_fifo_svalid;
-    
+
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][MAX_WR_RESP_COUNT -1:0][B_FIFO_WIDTH-1:0]       w_wr_resp_fifo_sdata;
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][MAX_WR_RESP_COUNT -1:0]                         w_wr_resp_fifo_svalid;
-    
+
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0] w_rd_data_fifo_sdata;
     logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0][R_FIFO_EXT_DATA_WIDTH -1:0]   w_rd_data_fifo_ext_sdata;
-    logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0]                               w_rd_data_fifo_svalid; 
-    
+    logic [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0]                               w_rd_data_fifo_svalid;
+
 //----------------------------------------------------------------------------
     logic                                   w_err_info_rid_mismatch_err;
     logic                                   w_err_info_split_bid_mismatch_err;
-    logic                                   w_axi_slv_bid_mismatch_error; 
+    logic                                   w_axi_slv_bid_mismatch_error;
     logic                                   w_axi_slv_rid_mismatch_error;
-    
+
     logic                                   w_int_early_resp_err;
     logic                                   w_int_activate_start_level;
     logic                                   w_int_deactivate_start_level;
@@ -450,7 +437,7 @@ import packet_def_pkg::*;
     logic                                   w_sw_reset;
     logic                                   r_sw_reset;
     logic                                   w_DFTED_sw_resetn;
-    logic                                   w_aou_sw_reset_scan_buf; 
+    logic                                   w_aou_sw_reset_scan_buf;
 
     logic [RP_COUNT-1:0]                    w_aou_rx_axi_s_rvalid;
     logic [RP_COUNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0]    w_rd_data_fifo_mdata;
@@ -458,16 +445,16 @@ import packet_def_pkg::*;
         .I_A   ( 1'b0                       ),
         .O_Y   ( w_aou_sw_reset_scan_buf    )
     );
-    
+
     AOU_SOC_GFMUX_LVT u_sw_reset_mux (
         .I_SEL ( TIEL_DFT_MODESCAN          ),
-    
+
         .I_A   ( ~r_sw_reset & I_RESETN     ),
         .I_B   ( w_aou_sw_reset_scan_buf    ),
-    
+
         .O_Y   ( w_DFTED_sw_resetn          )
     );
-    
+
     always @(posedge I_CLK or negedge I_RESETN) begin
         if (!I_RESETN) begin
             r_sw_reset <= 1'b0;
@@ -484,26 +471,26 @@ import packet_def_pkg::*;
     (
         .I_S_PCLK         ( I_PCLK                      ),
         .I_S_PRESETN      ( I_PRESETN                   ),
-    
+
         .I_S_PSEL         ( I_AOU_APB_SI0_PSEL          ),
         .I_S_PENABLE      ( I_AOU_APB_SI0_PENABLE       ),
         .I_S_PADDR        ( I_AOU_APB_SI0_PADDR         ),
         .I_S_PWRITE       ( I_AOU_APB_SI0_PWRITE        ),
         .I_S_PWDATA       ( I_AOU_APB_SI0_PWDATA        ),
-    
+
         .O_S_PRDATA       ( O_AOU_APB_SI0_PRDATA        ),
         .O_S_PREADY       ( O_AOU_APB_SI0_PREADY        ),
         .O_S_PSLVERR      ( O_AOU_APB_SI0_PSLVERR       ),
-    
+
         .I_M_PCLK         ( I_CLK                       ),
         .I_M_PRESETN      ( I_RESETN                    ),
-    
+
         .O_M_PSEL         ( w_aou_apb_si0_psel          ),
         .O_M_PENABLE      ( w_aou_apb_si0_penable       ),
         .O_M_PADDR        ( w_aou_apb_si0_paddr         ),
         .O_M_PWRITE       ( w_aou_apb_si0_pwrite        ),
         .O_M_PWDATA       ( w_aou_apb_si0_pwdata        ),
-    
+
         .I_M_PRDATA       ( w_aou_apb_si0_prdata        ),
         .I_M_PREADY       ( w_aou_apb_si0_pready        ),
         .I_M_PSLVERR      ( w_aou_apb_si0_pslverr       )
@@ -534,48 +521,48 @@ import packet_def_pkg::*;
         .RP3_RX_W_FIFO_DEPTH        ( RP3_RX_W_FIFO_DEPTH       ),
         .RP3_RX_R_FIFO_DEPTH        ( RP3_RX_R_FIFO_DEPTH       ),
         .RP3_RX_B_FIFO_DEPTH        ( RP3_RX_B_FIFO_DEPTH       ),
-                                             
+
         .RP0_AXI_DATA_WD            ( RP0_AXI_DATA_WD           ),
         .RP1_AXI_DATA_WD            ( RP1_AXI_DATA_WD           ),
         .RP2_AXI_DATA_WD            ( RP2_AXI_DATA_WD           ),
         .RP3_AXI_DATA_WD            ( RP3_AXI_DATA_WD           ),
 
         .AXI_PEER_DIE_MAX_DATA_WD   ( AXI_PEER_DIE_MAX_DATA_WD  ),
-       
+
         .APB_ADDR_WD                ( APB_ADDR_WD               ),
         .APB_DATA_WD                ( APB_DATA_WD               ),
-           
+
         .S_RD_MO_CNT                ( S_RD_MO_CNT               ),
         .S_WR_MO_CNT                ( S_WR_MO_CNT               ),
 
         .M_RD_MO_CNT                ( M_RD_MO_CNT               ),
         .M_WR_MO_CNT                ( M_WR_MO_CNT               ),
 
-        .AW_AR_FIFO_WIDTH           ( AW_AR_FIFO_WIDTH          ), 
-        .B_FIFO_WIDTH               ( B_FIFO_WIDTH              ), 
+        .AW_AR_FIFO_WIDTH           ( AW_AR_FIFO_WIDTH          ),
+        .B_FIFO_WIDTH               ( B_FIFO_WIDTH              ),
         .R_FIFO_EXT_DATA_WIDTH      ( R_FIFO_EXT_DATA_WIDTH     ),
- 
-        .FDI_IF_WD0                 ( FDI_IF_WD0                ),                                                                 
-        .FDI_IF_WD1                 ( FDI_IF_WD1                ), 
+
+        .FDI_IF_WD0                 ( FDI_IF_WD0                ),
+        .FDI_IF_WD1                 ( FDI_IF_WD1                ),
         .RP_COUNT                   ( RP_COUNT                  ),
         .DEC_MULTI                  ( DEC_MULTI                 ),
-        .PHY_TYPE                   ( PHY_TYPE                  ) 
+        .PHY_TYPE                   ( PHY_TYPE                  )
 
     ) u_aou_core
     (
         .I_CLK                              ( I_CLK                             ),
-        .I_RESETN                           ( w_DFTED_sw_resetn                 ),                                                                                                                    
-                                                                                                              
-        .I_AOU_APB_SI0_PSEL                 ( w_aou_apb_si0_psel                ),        
+        .I_RESETN                           ( w_DFTED_sw_resetn                 ),
+
+        .I_AOU_APB_SI0_PSEL                 ( w_aou_apb_si0_psel                ),
         .I_AOU_APB_SI0_PENABLE              ( w_aou_apb_si0_penable             ),
         .I_AOU_APB_SI0_PADDR                ( w_aou_apb_si0_paddr               ),
         .I_AOU_APB_SI0_PWRITE               ( w_aou_apb_si0_pwrite              ),
         .I_AOU_APB_SI0_PWDATA               ( w_aou_apb_si0_pwdata              ),
-                                                                                                                                                          
+
         .O_AOU_APB_SI0_PRDATA               ( w_aou_apb_si0_prdata              ),
         .O_AOU_APB_SI0_PREADY               ( w_aou_apb_si0_pready              ),
         .O_AOU_APB_SI0_PSLVERR              ( w_aou_apb_si0_pslverr             ),
-                                                                                                                                      
+
         .O_AOU_RX_AXI_M_ARID                ( O_AOU_RX_AXI_M_ARID               ),
         .O_AOU_RX_AXI_M_ARADDR              ( O_AOU_RX_AXI_M_ARADDR             ),
         .O_AOU_RX_AXI_M_ARLEN               ( O_AOU_RX_AXI_M_ARLEN              ),
@@ -587,14 +574,14 @@ import packet_def_pkg::*;
         .O_AOU_RX_AXI_M_ARQOS               ( O_AOU_RX_AXI_M_ARQOS              ),
         .O_AOU_RX_AXI_M_ARVALID             ( O_AOU_RX_AXI_M_ARVALID            ),
         .I_AOU_RX_AXI_M_ARREADY             ( I_AOU_RX_AXI_M_ARREADY            ),
-                  
+
         .I_AOU_TX_AXI_M_RID                 ( I_AOU_TX_AXI_M_RID                ),
         .I_AOU_TX_AXI_M_RDATA               ( I_AOU_TX_AXI_M_RDATA              ),
         .I_AOU_TX_AXI_M_RRESP               ( I_AOU_TX_AXI_M_RRESP              ),
         .I_AOU_TX_AXI_M_RLAST               ( I_AOU_TX_AXI_M_RLAST              ),
         .I_AOU_TX_AXI_M_RVALID              ( I_AOU_TX_AXI_M_RVALID             ),
         .O_AOU_TX_AXI_M_RREADY              ( O_AOU_TX_AXI_M_RREADY             ),
-                 
+
         .O_AOU_RX_AXI_M_AWID                ( O_AOU_RX_AXI_M_AWID               ),
         .O_AOU_RX_AXI_M_AWADDR              ( O_AOU_RX_AXI_M_AWADDR             ),
         .O_AOU_RX_AXI_M_AWLEN               ( O_AOU_RX_AXI_M_AWLEN              ),
@@ -606,74 +593,74 @@ import packet_def_pkg::*;
         .O_AOU_RX_AXI_M_AWQOS               ( O_AOU_RX_AXI_M_AWQOS              ),
         .O_AOU_RX_AXI_M_AWVALID             ( O_AOU_RX_AXI_M_AWVALID            ),
         .I_AOU_RX_AXI_M_AWREADY             ( I_AOU_RX_AXI_M_AWREADY            ),
-                
+
         .O_AOU_RX_AXI_M_WDATA               ( O_AOU_RX_AXI_M_WDATA              ),
         .O_AOU_RX_AXI_M_WSTRB               ( O_AOU_RX_AXI_M_WSTRB              ),
         .O_AOU_RX_AXI_M_WLAST               ( O_AOU_RX_AXI_M_WLAST              ),
         .O_AOU_RX_AXI_M_WVALID              ( O_AOU_RX_AXI_M_WVALID             ),
         .I_AOU_RX_AXI_M_WREADY              ( I_AOU_RX_AXI_M_WREADY             ),
-               
+
         .I_AOU_TX_AXI_M_BID                 ( I_AOU_TX_AXI_M_BID                ),
         .I_AOU_TX_AXI_M_BRESP               ( I_AOU_TX_AXI_M_BRESP              ),
         .I_AOU_TX_AXI_M_BVALID              ( I_AOU_TX_AXI_M_BVALID             ),
-        .O_AOU_TX_AXI_M_BREADY              ( O_AOU_TX_AXI_M_BREADY             ),                                                                                                         
-              
+        .O_AOU_TX_AXI_M_BREADY              ( O_AOU_TX_AXI_M_BREADY             ),
+
         .I_AOU_TX_AXI_S_ARID                ( I_AOU_TX_AXI_S_ARID               ),
         .I_AOU_TX_AXI_S_ARADDR              ( I_AOU_TX_AXI_S_ARADDR             ),
         .I_AOU_TX_AXI_S_ARLEN               ( I_AOU_TX_AXI_S_ARLEN              ),
         .I_AOU_TX_AXI_S_ARSIZE              ( I_AOU_TX_AXI_S_ARSIZE             ),
-        .I_AOU_TX_AXI_S_ARBURST             ( I_AOU_TX_AXI_S_ARBURST            ),         
+        .I_AOU_TX_AXI_S_ARBURST             ( I_AOU_TX_AXI_S_ARBURST            ),
         .I_AOU_TX_AXI_S_ARLOCK              ( I_AOU_TX_AXI_S_ARLOCK             ),
         .I_AOU_TX_AXI_S_ARCACHE             ( I_AOU_TX_AXI_S_ARCACHE            ),
         .I_AOU_TX_AXI_S_ARPROT              ( I_AOU_TX_AXI_S_ARPROT             ),
         .I_AOU_TX_AXI_S_ARQOS               ( I_AOU_TX_AXI_S_ARQOS              ),
         .I_AOU_TX_AXI_S_ARVALID             ( I_AOU_TX_AXI_S_ARVALID            ),
         .O_AOU_TX_AXI_S_ARREADY             ( O_AOU_TX_AXI_S_ARREADY            ),
-             
+
         .I_AOU_RX_AXI_S_RID                 ( O_AOU_RX_AXI_S_RID                ),
         .I_AOU_RX_AXI_S_RRESP               ( O_AOU_RX_AXI_S_RRESP              ),
         .I_AOU_RX_AXI_S_RLAST               ( O_AOU_RX_AXI_S_RLAST              ),
         .I_AOU_RX_AXI_S_RDLENGTH            ( w_aou_rx_axi_s_rdlength           ),
         .I_AOU_RX_AXI_S_RVALID              ( w_aou_rx_axi_s_rvalid             ),
         .I_AOU_RX_AXI_S_RREADY              ( I_AOU_RX_AXI_S_RREADY             ),
-            
+
         .I_AOU_TX_AXI_S_AWID                ( I_AOU_TX_AXI_S_AWID               ),
         .I_AOU_TX_AXI_S_AWADDR              ( I_AOU_TX_AXI_S_AWADDR             ),
         .I_AOU_TX_AXI_S_AWLEN               ( I_AOU_TX_AXI_S_AWLEN              ),
         .I_AOU_TX_AXI_S_AWSIZE              ( I_AOU_TX_AXI_S_AWSIZE             ),
-        .I_AOU_TX_AXI_S_AWBURST             ( I_AOU_TX_AXI_S_AWBURST            ),         
+        .I_AOU_TX_AXI_S_AWBURST             ( I_AOU_TX_AXI_S_AWBURST            ),
         .I_AOU_TX_AXI_S_AWLOCK              ( I_AOU_TX_AXI_S_AWLOCK             ),
         .I_AOU_TX_AXI_S_AWCACHE             ( I_AOU_TX_AXI_S_AWCACHE            ),
         .I_AOU_TX_AXI_S_AWPROT              ( I_AOU_TX_AXI_S_AWPROT             ),
         .I_AOU_TX_AXI_S_AWQOS               ( I_AOU_TX_AXI_S_AWQOS              ),
         .I_AOU_TX_AXI_S_AWVALID             ( I_AOU_TX_AXI_S_AWVALID            ),
         .O_AOU_TX_AXI_S_AWREADY             ( O_AOU_TX_AXI_S_AWREADY            ),
-           
+
         .I_AOU_TX_AXI_S_WDATA               ( I_AOU_TX_AXI_S_WDATA              ),
         .I_AOU_TX_AXI_S_WSTRB               ( I_AOU_TX_AXI_S_WSTRB              ),
         .I_AOU_TX_AXI_S_WLAST               ( I_AOU_TX_AXI_S_WLAST              ),
         .I_AOU_TX_AXI_S_WVALID              ( I_AOU_TX_AXI_S_WVALID             ),
         .O_AOU_TX_AXI_S_WREADY              ( O_AOU_TX_AXI_S_WREADY             ),
-          
+
         .O_AOU_RX_AXI_S_BID                 ( O_AOU_RX_AXI_S_BID                ),
         .O_AOU_RX_AXI_S_BRESP               ( O_AOU_RX_AXI_S_BRESP              ),
         .O_AOU_RX_AXI_S_BVALID              ( O_AOU_RX_AXI_S_BVALID             ),
         .I_AOU_RX_AXI_S_BREADY              ( I_AOU_RX_AXI_S_BREADY             ),
-                                
-        .I_AOU_RX_WLAST_GEN_AWID            ( w_aou_rx_wlast_gen_awid           ), 
+
+        .I_AOU_RX_WLAST_GEN_AWID            ( w_aou_rx_wlast_gen_awid           ),
         .I_AOU_RX_WLAST_GEN_AWADDR          ( w_aou_rx_wlast_gen_awaddr         ),
-        .I_AOU_RX_WLAST_GEN_AWLEN           ( w_aou_rx_wlast_gen_awlen          ),                      
+        .I_AOU_RX_WLAST_GEN_AWLEN           ( w_aou_rx_wlast_gen_awlen          ),
         .I_AOU_RX_WLAST_GEN_AWSIZE          ( w_aou_rx_wlast_gen_awsize         ),
         .I_AOU_RX_WLAST_GEN_AWLOCK          ( w_aou_rx_wlast_gen_awlock         ),
-        .I_AOU_RX_WLAST_GEN_AWCACHE         ( w_aou_rx_wlast_gen_awcache        ),                          
+        .I_AOU_RX_WLAST_GEN_AWCACHE         ( w_aou_rx_wlast_gen_awcache        ),
         .I_AOU_RX_WLAST_GEN_AWPROT          ( w_aou_rx_wlast_gen_awprot         ),
         .I_AOU_RX_WLAST_GEN_AWQOS           ( w_aou_rx_wlast_gen_awqos          ),
         .I_AOU_RX_WLAST_GEN_AWVALID         ( w_aou_rx_wlast_gen_awvalid        ),
-        .O_AOU_RX_WLAST_GEN_AWREADY         ( w_aou_rx_wlast_gen_awready        ),                                                          
-              
+        .O_AOU_RX_WLAST_GEN_AWREADY         ( w_aou_rx_wlast_gen_awready        ),
+
         .I_AOU_RX_WLAST_GEN_WDLENGTH        ( w_aou_rx_wlast_gen_wdlength       ),
-        .I_AOU_RX_WLAST_GEN_WDATAF          ( w_aou_rx_wlast_gen_wdataf         ),                            
-        .I_AOU_RX_WLAST_GEN_WDATA           ( w_aou_rx_wlast_gen_wdata          ),                       
+        .I_AOU_RX_WLAST_GEN_WDATAF          ( w_aou_rx_wlast_gen_wdataf         ),
+        .I_AOU_RX_WLAST_GEN_WDATA           ( w_aou_rx_wlast_gen_wdata          ),
         .I_AOU_RX_WLAST_GEN_WSTRB           ( w_aou_rx_wlast_gen_wstrb          ),
         .I_AOU_RX_WLAST_GEN_WVALID          ( w_aou_rx_wlast_gen_wvalid         ),
         .O_AOU_RX_WLAST_GEN_WREADY          ( w_aou_rx_wlast_gen_wready         ),
@@ -683,17 +670,17 @@ import packet_def_pkg::*;
         .I_EARLY_BRESP_CTRL_BVALID          ( w_early_bresp_ctrl_bvalid         ),
         .O_EARLY_BRESP_CTRL_BREADY          ( w_early_bresp_ctrl_bready         ),
 
-        .I_AOU_RX_AXI_MM_ARID               ( w_aou_rx_axi_mm_arid              ), 
-        .I_AOU_RX_AXI_MM_ARADDR             ( w_aou_rx_axi_mm_araddr            ), 
-        .I_AOU_RX_AXI_MM_ARLEN              ( w_aou_rx_axi_mm_arlen             ),     
-        .I_AOU_RX_AXI_MM_ARSIZE             ( w_aou_rx_axi_mm_arsize            ),         
-        .I_AOU_RX_AXI_MM_ARLOCK             ( w_aou_rx_axi_mm_arlock            ),     
-        .I_AOU_RX_AXI_MM_ARCACHE            ( w_aou_rx_axi_mm_arcache           ),     
-        .I_AOU_RX_AXI_MM_ARPROT             ( w_aou_rx_axi_mm_arprot            ),     
-        .I_AOU_RX_AXI_MM_ARQOS              ( w_aou_rx_axi_mm_arqos             ),     
-        .I_AOU_RX_AXI_MM_ARVALID            ( w_aou_rx_axi_mm_arvalid           ),                 
+        .I_AOU_RX_AXI_MM_ARID               ( w_aou_rx_axi_mm_arid              ),
+        .I_AOU_RX_AXI_MM_ARADDR             ( w_aou_rx_axi_mm_araddr            ),
+        .I_AOU_RX_AXI_MM_ARLEN              ( w_aou_rx_axi_mm_arlen             ),
+        .I_AOU_RX_AXI_MM_ARSIZE             ( w_aou_rx_axi_mm_arsize            ),
+        .I_AOU_RX_AXI_MM_ARLOCK             ( w_aou_rx_axi_mm_arlock            ),
+        .I_AOU_RX_AXI_MM_ARCACHE            ( w_aou_rx_axi_mm_arcache           ),
+        .I_AOU_RX_AXI_MM_ARPROT             ( w_aou_rx_axi_mm_arprot            ),
+        .I_AOU_RX_AXI_MM_ARQOS              ( w_aou_rx_axi_mm_arqos             ),
+        .I_AOU_RX_AXI_MM_ARVALID            ( w_aou_rx_axi_mm_arvalid           ),
         .O_AOU_RX_AXI_MM_ARREADY            ( w_aou_rx_axi_mm_arready           ),
-        
+
         .I_FDI_PL_0_VALID                   ( I_FDI_PL_0_VALID                    ),
         .I_FDI_PL_0_DATA                    ( I_FDI_PL_0_DATA                     ),
         .I_FDI_PL_0_FLIT_CANCEL             ( I_FDI_PL_0_FLIT_CANCEL              ),
@@ -707,8 +694,8 @@ import packet_def_pkg::*;
         .O_FDI_LP_0_STALLACK                ( O_FDI_LP_0_STALLACK                 ),
 
 `ifdef TWO_PHY
-        .I_PHY_TYPE                         ( I_PHY_TYPE                        ),                                                                                                                    
-                                                                         
+        .I_PHY_TYPE                         ( I_PHY_TYPE                        ),
+
         .I_FDI_PL_1_VALID                   ( I_FDI_PL_1_VALID                    ),
         .I_FDI_PL_1_DATA                    ( I_FDI_PL_1_DATA                     ),
         .I_FDI_PL_1_FLIT_CANCEL             ( I_FDI_PL_1_FLIT_CANCEL              ),
@@ -722,36 +709,36 @@ import packet_def_pkg::*;
         .O_FDI_LP_1_STALLACK                ( O_FDI_LP_1_STALLACK                 ),
 
 `endif
-                                            
-        .O_RD_REQ_FIFO_SDATA                ( w_rd_req_fifo_sdata               ),       
-        .O_RD_REQ_FIFO_SVALID               ( w_rd_req_fifo_svalid              ),  
-    
+
+        .O_RD_REQ_FIFO_SDATA                ( w_rd_req_fifo_sdata               ),
+        .O_RD_REQ_FIFO_SVALID               ( w_rd_req_fifo_svalid              ),
+
         .O_WR_REQ_FIFO_SDATA                ( w_wr_req_fifo_sdata               ),
-        .O_WR_REQ_FIFO_SVALID               ( w_wr_req_fifo_svalid              ),        
-            
-        .O_WR_DATA_FIFO_SDATA               ( w_wr_data_fifo_sdata              ),    
-        .O_WR_DATA_FIFO_SDATA_STRB          ( w_wr_data_fifo_sdata_strb         ),  
-        .O_WR_DATA_FIFO_SDATA_WDATAF        ( w_wr_data_fifo_sdata_wdataf       ),          
-        .O_WR_DATA_FIFO_SVALID              ( w_wr_data_fifo_svalid             ),        
+        .O_WR_REQ_FIFO_SVALID               ( w_wr_req_fifo_svalid              ),
+
+        .O_WR_DATA_FIFO_SDATA               ( w_wr_data_fifo_sdata              ),
+        .O_WR_DATA_FIFO_SDATA_STRB          ( w_wr_data_fifo_sdata_strb         ),
+        .O_WR_DATA_FIFO_SDATA_WDATAF        ( w_wr_data_fifo_sdata_wdataf       ),
+        .O_WR_DATA_FIFO_SVALID              ( w_wr_data_fifo_svalid             ),
 
         .O_WR_RESP_FIFO_SDATA               ( w_wr_resp_fifo_sdata              ),
-        .O_WR_RESP_FIFO_SVALID              ( w_wr_resp_fifo_svalid             ),        
-        
-        .O_RD_DATA_FIFO_SDATA               ( w_rd_data_fifo_sdata              ),                
-        .O_RD_DATA_FIFO_EXT_SDATA           ( w_rd_data_fifo_ext_sdata          ),                                   
-        .O_RD_DATA_FIFO_SVALID              ( w_rd_data_fifo_svalid             ),           
-                                            
-        .O_ERR_INFO_RID_MISMATCH_ERR        ( w_err_info_rid_mismatch_err       ),                           
-        .O_ERR_INFO_SPLIT_BID_MISMATCH_ERR  ( w_err_info_split_bid_mismatch_err ),  
+        .O_WR_RESP_FIFO_SVALID              ( w_wr_resp_fifo_svalid             ),
+
+        .O_RD_DATA_FIFO_SDATA               ( w_rd_data_fifo_sdata              ),
+        .O_RD_DATA_FIFO_EXT_SDATA           ( w_rd_data_fifo_ext_sdata          ),
+        .O_RD_DATA_FIFO_SVALID              ( w_rd_data_fifo_svalid             ),
+
+        .O_ERR_INFO_RID_MISMATCH_ERR        ( w_err_info_rid_mismatch_err       ),
+        .O_ERR_INFO_SPLIT_BID_MISMATCH_ERR  ( w_err_info_split_bid_mismatch_err ),
 
         .O_AXI_SLV_RID_MISMATCH_ERROR       ( w_axi_slv_rid_mismatch_error      ),
-        .O_AXI_SLV_BID_MISMATCH_ERROR       ( w_axi_slv_bid_mismatch_error      ),                                                                        
-                                                                                     
+        .O_AXI_SLV_BID_MISMATCH_ERROR       ( w_axi_slv_bid_mismatch_error      ),
+
         .O_INT_SLV_EARLY_RESP_ERR           ( w_int_early_resp_err              ),
 
         .O_INT_ACTIVATE_START               ( w_int_activate_start_level        ),
         .O_INT_DEACTIVATE_START             ( w_int_deactivate_start_level      ),
-                                                                                                                                                                                  
+
         .I_INT_FSM_IN_ACTIVE                ( I_INT_FSM_IN_ACTIVE               ),
         .I_MST_BUS_CLEANY_COMPLETE          ( I_MST_BUS_CLEANY_COMPLETE         ),
         .I_SLV_BUS_CLEANY_COMPLETE          ( I_SLV_BUS_CLEANY_COMPLETE         ),
@@ -766,7 +753,7 @@ import packet_def_pkg::*;
     );
 //----------------------------------------------------------------------------
     genvar i;
-    generate 
+    generate
         for(i = 0; i < RP_COUNT; i++) begin : gen_aou_fifo_rp
 
             AOU_FIFO_RP #(
@@ -784,66 +771,66 @@ import packet_def_pkg::*;
 
                 .DEC_MULTI                          ( DEC_MULTI                             ),
 
-                .AW_FWD_RS_EN                       ( RX_AW_FIFO_RS_EN                      ),    
+                .AW_FWD_RS_EN                       ( RX_AW_FIFO_RS_EN                      ),
                 .W_FWD_RS_EN                        ( RX_W_FIFO_RS_EN                       ),
-                .B_FWD_RS_EN                        ( RX_B_FIFO_RS_EN                       ),    
-                .AR_FWD_RS_EN                       ( RX_AR_FIFO_RS_EN                      ),    
+                .B_FWD_RS_EN                        ( RX_B_FIFO_RS_EN                       ),
+                .AR_FWD_RS_EN                       ( RX_AR_FIFO_RS_EN                      ),
                 .R_FWD_RS_EN                        ( RX_R_FIFO_RS_EN                       )
-    
+
             ) u_aou_fifo_rp
             (
-                .I_CLK                              ( I_CLK                                 ), 
+                .I_CLK                              ( I_CLK                                 ),
                 .I_RESETN                           ( I_RESETN                              ),
-                                                        
+
                 .I_WR_REQ_FIFO_SVALID               ( w_wr_req_fifo_svalid[i]               ),
                 .I_WR_REQ_FIFO_SDATA                ( w_wr_req_fifo_sdata[i]                ),
-                                                         
+
                 .I_WR_REQ_FIFO_MREADY               ( w_aou_rx_wlast_gen_awready[i]         ),
                 .O_WR_REQ_FIFO_MDATA                ( {w_aou_rx_wlast_gen_awid[i], w_aou_rx_wlast_gen_awaddr[i], w_aou_rx_wlast_gen_awlen[i], w_aou_rx_wlast_gen_awsize[i], w_aou_rx_wlast_gen_awlock[i], w_aou_rx_wlast_gen_awcache[i], w_aou_rx_wlast_gen_awprot[i], w_aou_rx_wlast_gen_awqos[i]} ),
                 .O_WR_REQ_FIFO_MVALID               ( w_aou_rx_wlast_gen_awvalid[i]         ),
-                                                         
+
                 .I_WR_DATA_FIFO_SVALID              ( w_wr_data_fifo_svalid[i]              ),
                 .I_WR_DATA_FIFO_SDATA               ( w_wr_data_fifo_sdata[i]               ),
                 .I_WR_DATA_FIFO_STRB                ( w_wr_data_fifo_sdata_strb[i]          ),
                 .I_WR_DATA_FIFO_WDATAF              ( w_wr_data_fifo_sdata_wdataf[i]        ),
-                                                 
+
                 .I_WR_DATA_FIFO_MREADY              ( w_aou_rx_wlast_gen_wready[i]          ),
                 .O_WR_DATA_FIFO_MDATA               ( w_aou_rx_wlast_gen_wdata[i]           ),
                 .O_WR_DATA_FIFO_MSTRB               ( w_aou_rx_wlast_gen_wstrb[i]           ),
                 .O_WR_DATA_FIFO_MDLEN               ( w_aou_rx_wlast_gen_wdlength[i]        ),
                 .O_WR_DATA_FIFO_WDATAF              ( w_aou_rx_wlast_gen_wdataf[i]          ),
                 .O_WR_DATA_FIFO_MVALID              ( w_aou_rx_wlast_gen_wvalid[i]          ),
-                                                 
+
                 .I_RD_REQ_FIFO_SVALID               ( w_rd_req_fifo_svalid[i]               ),
                 .I_RD_REQ_FIFO_SDATA                ( w_rd_req_fifo_sdata[i]                ),
-                                                  
+
                 .I_RD_REQ_FIFO_MREADY               ( w_aou_rx_axi_mm_arready[i]            ),
                 .O_RD_REQ_FIFO_MDATA                ( {w_aou_rx_axi_mm_arid[i], w_aou_rx_axi_mm_araddr[i], w_aou_rx_axi_mm_arlen[i], w_aou_rx_axi_mm_arsize[i], w_aou_rx_axi_mm_arlock[i], w_aou_rx_axi_mm_arcache[i], w_aou_rx_axi_mm_arprot[i], w_aou_rx_axi_mm_arqos[i]} ),
                 .O_RD_REQ_FIFO_MVALID               ( w_aou_rx_axi_mm_arvalid[i]            ),
-                                                 
-                .I_RD_DATA_FIFO_SVALID              ( w_rd_data_fifo_svalid[i]              ), 
+
+                .I_RD_DATA_FIFO_SVALID              ( w_rd_data_fifo_svalid[i]              ),
                 .I_RD_DATA_FIFO_SDATA               ( w_rd_data_fifo_sdata[i]               ),
                 .I_RD_DATA_FIFO_EXT_SDATA           ( w_rd_data_fifo_ext_sdata[i]           ),
-                                                 
+
                 .I_RD_DATA_FIFO_MREADY              ( I_AOU_RX_AXI_S_RREADY[i]              ),
                 .O_RD_DATA_FIFO_MDATA               ( w_rd_data_fifo_mdata[i]               ),
                 .O_RD_DATA_FIFO_EXT_MDATA           ( {O_AOU_RX_AXI_S_RID[i], O_AOU_RX_AXI_S_RRESP[i], O_AOU_RX_AXI_S_RLAST[i]} ),
                 .O_RD_DATA_FIFO_MDLEN               ( w_aou_rx_axi_s_rdlength[i]            ),
                 .O_RD_DATA_FIFO_MVALID              ( w_aou_rx_axi_s_rvalid[i]              ),
-                                                 
+
                 .I_WR_RESP_FIFO_SVALID              ( w_wr_resp_fifo_svalid[i]              ),
                 .I_WR_RESP_FIFO_SDATA               ( w_wr_resp_fifo_sdata[i]               ),
-                                                 
+
                 .I_WR_RESP_FIFO_MREADY              ( w_early_bresp_ctrl_bready[i]          ),
                 .O_WR_RESP_FIFO_MDATA               ( {w_early_bresp_ctrl_bid[i], w_early_bresp_ctrl_bresp[i]}  ),
                 .O_WR_RESP_FIFO_MVALID              ( w_early_bresp_ctrl_bvalid[i]          )
 
-            ); 
+            );
 
             assign  O_AOU_RX_AXI_S_RDATA[i] = w_rd_data_fifo_mdata[i][RP_AXI_DATA_WD_MAX-1:0];
 
         end
-    endgenerate 
+    endgenerate
 //----------------------------------------------------------------------------
 
     assign INT_DEACTIVATE_START = w_int_deactivate_start_level;

--- a/RTL/AOU_DATA_R_FIFO_NS1M.sv
+++ b/RTL/AOU_DATA_R_FIFO_NS1M.sv
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -28,7 +29,7 @@
 module AOU_DATA_R_FIFO_NS1M
 #(
     parameter   AXI_PEER_DIE_MAX_DATA_WD = 1024,
-    localparam  DATA_FIFO_WD    = 256,      
+    localparam  DATA_FIFO_WD    = 256,
     parameter   FIFO_DEPTH      = 64,          // depth
     parameter   ICH_CNT         = 8, // input channel count
     parameter   DEC_MULTI       = 2,
@@ -36,7 +37,7 @@ module AOU_DATA_R_FIFO_NS1M
     localparam  REQ_CNT_WD      = $clog2(REQ_CNT+1),
     parameter   ALWAYS_READY    = 0,
     parameter   EXT_FIFO_WD     = 13, //for R: RID + RRESP + RLAST //for W: 0
-    
+
     localparam  AXI_CON         = AXI_PEER_DIE_MAX_DATA_WD/DATA_FIFO_WD,
     localparam  ICH_CNT_WD      = $clog2(ICH_CNT+1),
     localparam  AW              = $clog2(FIFO_DEPTH)
@@ -49,7 +50,7 @@ module AOU_DATA_R_FIFO_NS1M
     input  [ICH_CNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0]  I_SDATA,//0: 1024bit 1: 512bit 2,3: 256bit //for W: sdata + sdata_strb
     input  [ICH_CNT-1:0][EXT_FIFO_WD-1:0]               I_EXT_SDATA,
     output                                              O_SREADY,
-    
+
     input                                               I_MREADY,
     output [AXI_PEER_DIE_MAX_DATA_WD-1:0]               O_MDATA,
     output [EXT_FIFO_WD-1:0]                            O_EXT_MDATA,
@@ -64,7 +65,7 @@ module AOU_DATA_R_FIFO_NS1M
     logic [AW-1:0]                                      w_ext_ptr;
     logic [ICH_CNT_WD-1:0]                              w_ext_req_cnt;
     logic [ICH_CNT-1:0][AW-1:0]                         nxt_w_ext_ptr;
-  
+
     logic                                               r_ex_ext_ptr;
     logic                                               w_ex_ext_ptr;
 
@@ -95,7 +96,7 @@ module AOU_DATA_R_FIFO_NS1M
         w_ext_req_cnt = 'd0;
         for(int dec_multi = 0; dec_multi < DEC_MULTI; dec_multi = dec_multi + 1) begin
             if(I_SVALID[dec_multi*4+0]) begin
-            for(idx_write_req = 0; idx_write_req < 4; idx_write_req = idx_write_req + 1) begin 
+            for(idx_write_req = 0; idx_write_req < 4; idx_write_req = idx_write_req + 1) begin
                     nxt_data[dec_multi*4+0][idx_write_req] = I_SDATA[dec_multi*4+0][(DATA_FIFO_WD*idx_write_req) +: DATA_FIFO_WD];
                     nxt_w_data_ptr[dec_multi*4+0][idx_write_req] = (w_data_ptr + w_data_req_cnt >= FIFO_DEPTH) ? (w_data_ptr + w_data_req_cnt - FIFO_DEPTH) : (w_data_ptr + w_data_req_cnt);
                     w_data_req_valid[dec_multi*4+0][idx_write_req] = 1;
@@ -123,7 +124,7 @@ module AOU_DATA_R_FIFO_NS1M
                     w_data_req_cnt = w_data_req_cnt + 1;
                 end
                 nxt_ext_data[dec_multi*4+2] = {I_EXT_SDATA[dec_multi*4+2],2'b00};
-                nxt_w_ext_ptr[dec_multi*4+2] = (w_ext_ptr + w_ext_req_cnt >= FIFO_DEPTH) ? (w_ext_ptr + w_ext_req_cnt - FIFO_DEPTH) : (w_ext_ptr + w_ext_req_cnt); 
+                nxt_w_ext_ptr[dec_multi*4+2] = (w_ext_ptr + w_ext_req_cnt >= FIFO_DEPTH) ? (w_ext_ptr + w_ext_req_cnt - FIFO_DEPTH) : (w_ext_ptr + w_ext_req_cnt);
                 w_ext_req_cnt = w_ext_req_cnt + 1;
             end
             if(I_SVALID[dec_multi*4+3]) begin
@@ -131,16 +132,23 @@ module AOU_DATA_R_FIFO_NS1M
                     nxt_data[dec_multi*4+3][idx_write_req] = I_SDATA[dec_multi*4+3][(DATA_FIFO_WD*idx_write_req) +: DATA_FIFO_WD];
                     nxt_w_data_ptr[dec_multi*4+3][idx_write_req] = (w_data_ptr + w_data_req_cnt >= FIFO_DEPTH) ? (w_data_ptr + w_data_req_cnt - FIFO_DEPTH) : (w_data_ptr + w_data_req_cnt);
                     w_data_req_valid[dec_multi*4+3][idx_write_req] = 1;
-                    w_data_req_cnt = w_data_req_cnt + 1;                   
+                    w_data_req_cnt = w_data_req_cnt + 1;
                 end
                 nxt_ext_data[dec_multi*4+3] = {I_EXT_SDATA[dec_multi*4+3],2'b00};
-                nxt_w_ext_ptr[dec_multi*4+3] = (w_ext_ptr + w_ext_req_cnt >= FIFO_DEPTH) ? (w_ext_ptr + w_ext_req_cnt - FIFO_DEPTH) : (w_ext_ptr + w_ext_req_cnt); 
+                nxt_w_ext_ptr[dec_multi*4+3] = (w_ext_ptr + w_ext_req_cnt >= FIFO_DEPTH) ? (w_ext_ptr + w_ext_req_cnt - FIFO_DEPTH) : (w_ext_ptr + w_ext_req_cnt);
                 w_ext_req_cnt = w_ext_req_cnt + 1;
             end
         end
     end
 
-    //for write 
+    //for write
+    //
+    // Writes to data_fifo and ext_fifo are expressed as per-entry mux/enable
+    // networks (outer loop sweeps the storage entry, inner loops scan the
+    // input channels) so the indexed selects never appear with an out-of-range
+    // address when FIFO_DEPTH is not a power of two. This avoids the X
+    // don't-care lanes that would otherwise expand into a large set of LEC
+    // "E" key points (with the associated runtime / abort cost).
     integer i, j;
     always_ff @ (posedge I_CLK or negedge I_RESETN) begin
         if (~I_RESETN) begin
@@ -152,14 +160,19 @@ module AOU_DATA_R_FIFO_NS1M
             w_ext_ptr <= 0;
             w_ex_ext_ptr <= 0;
         end else begin
-            for (i = 0; i < ICH_CNT; i = i + 1) begin
-                if(I_SVALID[i] && O_SREADY) begin
-                    for(j = 0; j < AXI_CON; j = j + 1)begin
-                        if(w_data_req_valid[i][j]) begin
-                            data_fifo[nxt_w_data_ptr[i][j]] <= nxt_data[i][j];
+            for (int k = 0; k < FIFO_DEPTH; k = k+1) begin
+                for (int wi = 0; wi < ICH_CNT; wi = wi+1) begin
+                    if (I_SVALID[wi] && O_SREADY) begin
+                        if (nxt_w_ext_ptr[wi][AW-1:0] == k[AW-1:0]) begin
+                            ext_fifo[k] <= nxt_ext_data[wi];
+                        end
+                        for (int wj = 0; wj < AXI_CON; wj = wj+1) begin
+                            if (w_data_req_valid[wi][wj] &&
+                                (nxt_w_data_ptr[wi][wj][AW-1:0] == k[AW-1:0])) begin
+                                data_fifo[k] <= nxt_data[wi][wj];
+                            end
+                        end
                     end
-                    end
-                    ext_fifo[nxt_w_ext_ptr[i]] <= nxt_ext_data[i];  
                 end
             end
             if((|I_SVALID) && O_SREADY) begin
@@ -169,8 +182,21 @@ module AOU_DATA_R_FIFO_NS1M
             end
         end
     end
-                      
-    assign O_MDLEN = ext_fifo[r_ext_ptr][1:0];
+
+    // Read mux for ext_fifo. Built as a single explicit one-hot select over
+    // the reachable index range [0, FIFO_DEPTH-1] -- both O_MDLEN and
+    // O_EXT_MDATA tap the same r_ext_ptr, so we materialise the entry once
+    // and slice it for the two consumers below. This avoids out-of-range X
+    // don't-cares on r_ext_ptr (same motivation as the write port).
+    logic [EXT_FIFO_WD+1:0] w_ext_rd_data;
+    always_comb begin
+        w_ext_rd_data = '0;
+        for (int k = 0; k < FIFO_DEPTH; k = k+1) begin
+            if (r_ext_ptr == k[AW-1:0]) w_ext_rd_data = ext_fifo[k];
+        end
+    end
+
+    assign O_MDLEN = w_ext_rd_data[1:0];
     //for read
     always_ff @ (posedge I_CLK or negedge I_RESETN ) begin
         if (~I_RESETN) begin
@@ -185,7 +211,7 @@ module AOU_DATA_R_FIFO_NS1M
                 end else if(O_MDLEN == 2'b01) begin
                     r_data_ptr <= (r_data_ptr + 2 >= FIFO_DEPTH) ? (r_data_ptr + 2 - FIFO_DEPTH) : (r_data_ptr + 2);
                 end else begin
-                    r_data_ptr <= (r_data_ptr + 1 >= FIFO_DEPTH) ? (r_data_ptr + 1 - FIFO_DEPTH) : (r_data_ptr + 1);        
+                    r_data_ptr <= (r_data_ptr + 1 >= FIFO_DEPTH) ? (r_data_ptr + 1 - FIFO_DEPTH) : (r_data_ptr + 1);
                 end
                 r_ext_ptr <= (r_ext_ptr + 1 == FIFO_DEPTH) ? 0 : (r_ext_ptr + 1);
                 r_ex_ext_ptr <= (r_ext_ptr + 1 == FIFO_DEPTH) ? ~r_ex_ext_ptr : r_ex_ext_ptr;
@@ -202,18 +228,23 @@ module AOU_DATA_R_FIFO_NS1M
         mdata = 'd0;
         r_data_req_cnt = 'd0;
         r_data_ptr_tmp = 'd0;
-       
+
         for(l = 0; l < AXI_CON; l = l + 1) begin
            if(l < (1 << O_MDLEN)) begin
                 r_data_ptr_tmp = (r_data_ptr + r_data_req_cnt >= FIFO_DEPTH) ? (r_data_ptr + r_data_req_cnt - FIFO_DEPTH) : (r_data_ptr + r_data_req_cnt);
-                mdata[l] = data_fifo[r_data_ptr_tmp];
+                // Explicit one-hot mux over the reachable index range so
+                // r_data_ptr_tmp values in the unreachable range do not
+                // introduce out-of-range X don't-cares.
+                for (int k = 0; k < FIFO_DEPTH; k = k+1) begin
+                    if (r_data_ptr_tmp == k[AW-1:0]) mdata[l] = data_fifo[k];
+                end
                 r_data_req_cnt = r_data_req_cnt + 1;
             end
         end
     end
-              
+
     assign O_MDATA = (O_MDLEN == 2'b00) ? {AXI_CON{mdata[0]}} : (O_MDLEN == 2'b01) ? (AXI_CON != 2) ? {2{mdata[1:0]}} : mdata : mdata;
-    assign O_EXT_MDATA = ext_fifo[r_ext_ptr][2 +: EXT_FIFO_WD];
+    assign O_EXT_MDATA = w_ext_rd_data[2 +: EXT_FIFO_WD];
     assign O_MVALID = ~((r_ex_ext_ptr == w_ex_ext_ptr) && (r_ext_ptr == w_ext_ptr));
     assign O_SREADY = (ALWAYS_READY) ? 1 : (~fifo_full);
 

--- a/RTL/AOU_DATA_W_FIFO_NS1M.sv
+++ b/RTL/AOU_DATA_W_FIFO_NS1M.sv
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -30,7 +31,7 @@ module AOU_DATA_W_FIFO_NS1M
     parameter   AXI_PEER_DIE_MAX_DATA_WD = 1024,
     localparam  AXI_STRB_WD     = AXI_PEER_DIE_MAX_DATA_WD/8,
     localparam  DATA_FIFO_WD    = 256,
-    localparam  STRB_FIFO_WD    = DATA_FIFO_WD/8,  
+    localparam  STRB_FIFO_WD    = DATA_FIFO_WD/8,
     parameter   FIFO_DEPTH      = 64,          // depth
     parameter   ICH_CNT         = 8,          // input channel count
     parameter   DEC_MULTI       = 2,
@@ -48,11 +49,11 @@ module AOU_DATA_W_FIFO_NS1M
     input                                   I_RESETN,
 
     input  [ICH_CNT-1:0]                    I_SVALID,
-    input  [ICH_CNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0]  I_SDATA,//0: 1024bit 1: 512bit 2,3: 256bit 
+    input  [ICH_CNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0]  I_SDATA,//0: 1024bit 1: 512bit 2,3: 256bit
     input  [ICH_CNT-1:0][AXI_STRB_WD-1:0]   I_SDATA_STRB,
     input  [ICH_CNT-1:0]                    I_SDATA_WDATAF,
     output                                  O_SREADY,
-    
+
     input                                   I_MREADY,
     output [AXI_PEER_DIE_MAX_DATA_WD-1:0]   O_MDATA,
     output [AXI_STRB_WD-1:0]                O_MDATA_STRB,
@@ -83,7 +84,7 @@ module AOU_DATA_W_FIFO_NS1M
 
     logic                                               fifo_full;
 //--------------------------------------------------------------------------
-    integer idx_write_req;   
+    integer idx_write_req;
     always_comb begin
         w_data_req_cnt  = 'd0;
         nxt_data        = 'd0;
@@ -92,7 +93,7 @@ module AOU_DATA_W_FIFO_NS1M
         nxt_strb_data    = 'd0;
         for(int dec_multi = 0; dec_multi < DEC_MULTI; dec_multi = dec_multi + 1) begin
             if(I_SVALID[dec_multi*4+0]) begin
-            for(idx_write_req = 0; idx_write_req < 4; idx_write_req = idx_write_req + 1) begin 
+            for(idx_write_req = 0; idx_write_req < 4; idx_write_req = idx_write_req + 1) begin
                     nxt_data[dec_multi*4+0][idx_write_req] = I_SDATA[dec_multi*4+0][(DATA_FIFO_WD*idx_write_req) +: DATA_FIFO_WD];
                     nxt_w_data_ptr[dec_multi*4+0][idx_write_req] = (w_data_ptr + w_data_req_cnt >= FIFO_DEPTH) ? (w_data_ptr + w_data_req_cnt - FIFO_DEPTH) : (w_data_ptr + w_data_req_cnt);
                     nxt_strb_data[dec_multi*4+0][idx_write_req] = {I_SDATA_STRB[dec_multi*4+0][(STRB_FIFO_WD*idx_write_req) +: STRB_FIFO_WD], I_SDATA_WDATAF[dec_multi*4+0], 2'b10};
@@ -106,7 +107,7 @@ module AOU_DATA_W_FIFO_NS1M
                     nxt_strb_data[dec_multi*4+1][idx_write_req] = {I_SDATA_STRB[dec_multi*4+1][(STRB_FIFO_WD*idx_write_req) +: STRB_FIFO_WD], I_SDATA_WDATAF[dec_multi*4+1], 2'b01};
                     w_data_req_valid[dec_multi*4+1][idx_write_req] = 1;
                 w_data_req_cnt = w_data_req_cnt + 1;
-            end        
+            end
         end
             if(I_SVALID[dec_multi*4+2]) begin
             for(idx_write_req = 0; idx_write_req < 1; idx_write_req = idx_write_req + 1) begin
@@ -115,7 +116,7 @@ module AOU_DATA_W_FIFO_NS1M
                     nxt_strb_data[dec_multi*4+2][idx_write_req] = {I_SDATA_STRB[dec_multi*4+2][(STRB_FIFO_WD*idx_write_req) +: STRB_FIFO_WD], I_SDATA_WDATAF[dec_multi*4+2], 2'b00};
                     w_data_req_valid[dec_multi*4+2][idx_write_req] = 1;
                 w_data_req_cnt = w_data_req_cnt + 1;
-            end 
+            end
         end
             if(I_SVALID[dec_multi*4+3]) begin
             for(idx_write_req = 0; idx_write_req < 1; idx_write_req = idx_write_req + 1) begin
@@ -123,13 +124,20 @@ module AOU_DATA_W_FIFO_NS1M
                     nxt_w_data_ptr[dec_multi*4+3][idx_write_req] = (w_data_ptr + w_data_req_cnt >= FIFO_DEPTH) ? (w_data_ptr + w_data_req_cnt - FIFO_DEPTH) : (w_data_ptr + w_data_req_cnt);
                     nxt_strb_data[dec_multi*4+3][idx_write_req] = {I_SDATA_STRB[dec_multi*4+3][(STRB_FIFO_WD*idx_write_req) +: STRB_FIFO_WD], I_SDATA_WDATAF[dec_multi*4+3], 2'b00};
                     w_data_req_valid[dec_multi*4+3][idx_write_req] = 1;
-                w_data_req_cnt = w_data_req_cnt + 1;  
+                w_data_req_cnt = w_data_req_cnt + 1;
             end
         end
     end
     end
 
-    //for write 
+    //for write
+    //
+    // Writes to data_fifo and strb_fifo are expressed as per-entry mux/enable
+    // networks (outer loop sweeps the storage entry, inner loops scan the
+    // input channels) so the indexed selects never appear with an out-of-range
+    // address when FIFO_DEPTH is not a power of two. This avoids the X
+    // don't-care lanes that would otherwise expand into a large set of LEC
+    // "E" key points (with the associated runtime / abort cost).
     integer i, j;
     always_ff @ (posedge I_CLK or negedge I_RESETN) begin
     if (~I_RESETN) begin
@@ -140,25 +148,41 @@ module AOU_DATA_W_FIFO_NS1M
             w_data_ptr <= 0;
             w_ex_data_ptr <= 0;
     end else begin
-        for (i = 0; i < ICH_CNT; i = i + 1) begin
-            if(I_SVALID[i] && O_SREADY) begin
-                for(j = 0; j < AXI_CON; j = j + 1)begin
-                    if(w_data_req_valid[i][j]) begin
-                        data_fifo[nxt_w_data_ptr[i][j]] <= nxt_data[i][j];
-                        strb_fifo[nxt_w_data_ptr[i][j]] <= nxt_strb_data[i][j];
+            for (int k = 0; k < FIFO_DEPTH; k = k+1) begin
+                for (int wi = 0; wi < ICH_CNT; wi = wi+1) begin
+                    if (I_SVALID[wi] && O_SREADY) begin
+                        for (int wj = 0; wj < AXI_CON; wj = wj+1) begin
+                            if (w_data_req_valid[wi][wj] &&
+                                (nxt_w_data_ptr[wi][wj][AW-1:0] == k[AW-1:0])) begin
+                                data_fifo[k] <= nxt_data[wi][wj];
+                                strb_fifo[k] <= nxt_strb_data[wi][wj];
+                            end
+                        end
                     end
                 end
-                end
             end
-            if((|I_SVALID) && O_SREADY) begin 
+            if((|I_SVALID) && O_SREADY) begin
                 w_data_ptr <= (w_data_ptr + w_data_req_cnt >= FIFO_DEPTH) ? (w_data_ptr + w_data_req_cnt - FIFO_DEPTH) : (w_data_ptr + w_data_req_cnt);
                 w_ex_data_ptr <= (w_data_ptr + w_data_req_cnt  >= FIFO_DEPTH) ? ~w_ex_data_ptr : w_ex_data_ptr;
             end
         end
     end
 
-    assign O_MDLEN          = strb_fifo[r_data_ptr][1:0];
-    assign O_MDATA_WDATAF   = strb_fifo[r_data_ptr][2];
+    // Read mux for strb_fifo. Built as a single explicit one-hot select over
+    // the reachable index range [0, FIFO_DEPTH-1] -- both O_MDLEN and
+    // O_MDATA_WDATAF tap the same r_data_ptr, so we materialise the entry
+    // once and slice it for the two consumers below. This avoids out-of-range
+    // X don't-cares on r_data_ptr (same motivation as the write port).
+    logic [STRB_FIFO_WD+2:0] w_strb_rd_data;
+    always_comb begin
+        w_strb_rd_data = '0;
+        for (int k = 0; k < FIFO_DEPTH; k = k+1) begin
+            if (r_data_ptr == k[AW-1:0]) w_strb_rd_data = strb_fifo[k];
+        end
+    end
+
+    assign O_MDLEN          = w_strb_rd_data[1:0];
+    assign O_MDATA_WDATAF   = w_strb_rd_data[2];
     //for read
     always_ff @ (posedge I_CLK or negedge I_RESETN) begin
         if (~I_RESETN) begin
@@ -173,7 +197,7 @@ module AOU_DATA_W_FIFO_NS1M
                     r_data_ptr <= (r_data_ptr + 2 >= FIFO_DEPTH) ? (r_data_ptr + 2 - FIFO_DEPTH) : (r_data_ptr + 2);
                     r_ex_data_ptr <= (r_data_ptr + 2 >= FIFO_DEPTH) ? ~r_ex_data_ptr : r_ex_data_ptr;
                 end else begin
-                    r_data_ptr <= (r_data_ptr + 1 == FIFO_DEPTH) ? (r_data_ptr + 1 - FIFO_DEPTH) : (r_data_ptr + 1);    
+                    r_data_ptr <= (r_data_ptr + 1 == FIFO_DEPTH) ? (r_data_ptr + 1 - FIFO_DEPTH) : (r_data_ptr + 1);
                     r_ex_data_ptr <= (r_data_ptr + 1 >= FIFO_DEPTH) ? ~r_ex_data_ptr : r_ex_data_ptr;
                 end
             end
@@ -181,7 +205,7 @@ module AOU_DATA_W_FIFO_NS1M
     end
 
     assign fifo_full = ((r_data_ptr == w_data_ptr) && (r_ex_data_ptr != w_ex_data_ptr));
-            
+
     integer l;
     logic [ICH_CNT_WD-1:0] r_data_req_cnt;
     logic [AW-1:0] r_data_ptr_tmp;
@@ -194,13 +218,22 @@ module AOU_DATA_W_FIFO_NS1M
         for(l = 0; l < AXI_CON; l = l + 1) begin
            if(l < (1 << O_MDLEN)) begin
                 r_data_ptr_tmp = (r_data_ptr + r_data_req_cnt >= FIFO_DEPTH) ? (r_data_ptr + r_data_req_cnt - FIFO_DEPTH) : (r_data_ptr + r_data_req_cnt);
-                mdata[l] = data_fifo[r_data_ptr_tmp];
-                mstrb[l] = strb_fifo[r_data_ptr_tmp][3 +: STRB_FIFO_WD];
+                // Explicit one-hot mux over the reachable index range so
+                // r_data_ptr_tmp values in the unreachable range do not
+                // introduce out-of-range X don't-cares. data_fifo and
+                // strb_fifo share the same address, so they reuse the same
+                // one-hot decode.
+                for (int k = 0; k < FIFO_DEPTH; k = k+1) begin
+                    if (r_data_ptr_tmp == k[AW-1:0]) begin
+                        mdata[l] = data_fifo[k];
+                        mstrb[l] = strb_fifo[k][3 +: STRB_FIFO_WD];
+                    end
+                end
                 r_data_req_cnt = r_data_req_cnt + 1;
     end
         end
     end
-              
+
     assign O_MDATA = (O_MDLEN == 2'b00) ? {{(AXI_PEER_DIE_MAX_DATA_WD - 256){1'b0}}, mdata[0]} : (O_MDLEN == 2'b01) ? {{(AXI_PEER_DIE_MAX_DATA_WD - 512){1'b0}}, mdata[1:0]} : mdata;
     assign O_MDATA_STRB = (O_MDLEN == 2'b00) ? {{(AXI_STRB_WD - 32){1'b0}}, mstrb[0]} : (O_MDLEN == 2'b01) ? {{(AXI_STRB_WD - 64){1'b0}}, mstrb[1:0]} : mstrb;
     assign O_MVALID = ~((r_ex_data_ptr == w_ex_data_ptr) && (r_data_ptr == w_data_ptr));

--- a/RTL/AOU_DATA_W_FIFO_NS1M.sv
+++ b/RTL/AOU_DATA_W_FIFO_NS1M.sv
@@ -138,7 +138,7 @@ module AOU_DATA_W_FIFO_NS1M
     // address when FIFO_DEPTH is not a power of two. This avoids the X
     // don't-care lanes that would otherwise expand into a large set of LEC
     // "E" key points (with the associated runtime / abort cost).
-    integer i, j;
+    integer i;
     always_ff @ (posedge I_CLK or negedge I_RESETN) begin
     if (~I_RESETN) begin
             for (i = 0; i < FIFO_DEPTH; i = i+1) begin

--- a/RTL/AOU_RX_CORE.sv
+++ b/RTL/AOU_RX_CORE.sv
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -25,8 +26,8 @@
 
 `timescale 1ns/1ps
 
-import packet_def_pkg::*; 
-module AOU_RX_CORE 
+import packet_def_pkg::*;
+module AOU_RX_CORE
 
 #(
     parameter   PHY_TYPE                    = 2, //0:32B, 1:64B, 2:128B, 3:256B
@@ -39,7 +40,7 @@ module AOU_RX_CORE
     parameter   AXI_ID_WD                   = 10,
     parameter   AXI_LEN_WD                  = 8,
     localparam  AXI_STRB_WD                 = AXI_PEER_DIE_MAX_DATA_WD / 8,
-    
+
     parameter   MAX_MISC_COUNT_CHUNK        = 2,
     parameter   MAX_REQ_COUNT_CHUNK         = 4,
     parameter   MAX_DATA_COUNT_CHUNK        = 2,
@@ -49,7 +50,7 @@ module AOU_RX_CORE
     localparam  MAX_REQ_COUNT_WD            = $clog2(MAX_REQ_COUNT_CHUNK + 1),
     localparam  MAX_DATA_COUNT_WD           = $clog2(MAX_DATA_COUNT_CHUNK + 1),
     localparam  MAX_WR_RESP_COUNT_WD        = $clog2(MAX_WR_RESP_COUNT_CHUNK + 1),
-    
+
     localparam  MAX_MISC_WD                 = $clog2(MAX_MISC_COUNT_CHUNK),
     localparam  MAX_REQ_WD                  = $clog2(MAX_REQ_COUNT_CHUNK),
     localparam  MAX_DATA_WD                 = $clog2(MAX_DATA_COUNT_CHUNK),
@@ -61,7 +62,7 @@ module AOU_RX_CORE
     parameter   R_FIFO_EXT_DATA_WIDTH       = 15,
     parameter   B_FIFO_DATA_WIDTH           = 12
 )
-( 
+(
     input                                                                                       I_CLK,
     input                                                                                       I_RESETN,
 
@@ -76,8 +77,8 @@ module AOU_RX_CORE
     output  [RP_COUNT-1:0][DEC_MULTI-1:0][MAX_REQ_COUNT_CHUNK-1:0]                              O_WR_REQ_FIFO_SVALID,
 
     output  [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0][AXI_PEER_DIE_MAX_DATA_WD-1:0]       O_WR_DATA_FIFO_SDATA,
-    output  [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0][AXI_STRB_WD-1:0]                    O_WR_DATA_FIFO_SDATA_STRB, 
-    output  [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0]                                     O_WR_DATA_FIFO_SDATA_WDATAF,                                  
+    output  [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0][AXI_STRB_WD-1:0]                    O_WR_DATA_FIFO_SDATA_STRB,
+    output  [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0]                                     O_WR_DATA_FIFO_SDATA_WDATAF,
     output  [RP_COUNT-1:0][DEC_MULTI-1:0][DATA_DEC_CNT-1:0]                                     O_WR_DATA_FIFO_SVALID,
 
     output  [RP_COUNT-1:0][DEC_MULTI-1:0][MAX_WR_RESP_COUNT_CHUNK-1:0][B_FIFO_DATA_WIDTH-1:0]   O_WR_RESP_FIFO_SDATA,
@@ -126,14 +127,14 @@ module AOU_RX_CORE
     st_g_packet [11:0]                  zero_g;
     st_g_packet [2:0][11:0]             r_g;     //maximum 30 granules uses. therefore at least 3 register(3 cycle) needed to cover continue messages.
     st_g_packet [(DEC_MULTI+3)*12-1:0]  w_g;
-    
+
     logic [FDI_IF_WD-1:0]       w_rx_chunk_data;
     logic                       w_rx_chunk_data_valid;
-    logic [DEC_MULTI-1:0][11:0] i_msg_start;    //protocol header per chunk   
-    
+    logic [DEC_MULTI-1:0][11:0] i_msg_start;    //protocol header per chunk
+
     logic [2:0]                 r_fdi_pl_data_valid;
     logic [PHASE_CNT_WD-1:0]    r_aou_rx_phase;
-    
+
     st_msg_credit_packet        i_msg_credit;
 
 //-------------------------------------------------------------
@@ -143,49 +144,49 @@ module AOU_RX_CORE
     logic [DEC_MULTI-1:0][11:0]                             i_write_data_start;
     logic [DEC_MULTI-1:0][11:0]                             i_read_data_start;
     logic [DEC_MULTI-1:0][11:0]                             i_write_resp_start;
-    
-    logic [DEC_MULTI-1:0][MAX_MISC_COUNT_CHUNK-1:0][3:0]    i_misc_idx;     
+
+    logic [DEC_MULTI-1:0][MAX_MISC_COUNT_CHUNK-1:0][3:0]    i_misc_idx;
     logic [DEC_MULTI-1:0][MAX_MISC_COUNT_CHUNK-1:0]         i_misc_valid;
     logic [DEC_MULTI-1:0][MAX_MISC_COUNT_WD-1:0]            i_misc_cnt;
     logic [MAX_MISC_COUNT_WD-1:0]                           w_misc_cnt_for_wait;
-    
+
     logic [MAX_MISC_COUNT_CHUNK-1:0][3:0]                   r_misc_idx;
     logic [MAX_MISC_COUNT_CHUNK-1:0]                        r_misc_valid;
     logic [MAX_MISC_COUNT_WD-1:0]                           r_misc_cnt;
     logic [1:0][MAX_MISC_COUNT_CHUNK-1:0][3:0]              w_misc_idx;
     logic [1:0][MAX_MISC_COUNT_CHUNK-1:0]                   w_misc_valid;
     logic [1:0][MAX_MISC_COUNT_WD-1:0]                      w_misc_cnt;
-    
+
     logic [DEC_MULTI-1:0][MAX_REQ_COUNT_CHUNK-1:0][3:0]     i_write_req_idx;
     logic [DEC_MULTI-1:0][MAX_REQ_COUNT_CHUNK-1:0]          i_write_req_valid;
     logic [DEC_MULTI-1:0][MAX_REQ_COUNT_WD-1:0]             i_write_req_cnt;
     logic [MAX_REQ_COUNT_WD-1:0]                            w_write_req_cnt_for_wait;
-    
+
     logic [MAX_REQ_COUNT_CHUNK-1:0][3:0]                    r_write_req_idx;
     logic [MAX_REQ_COUNT_CHUNK-1:0]                         r_write_req_valid;
     logic [MAX_REQ_COUNT_WD-1:0]                            r_write_req_cnt;
     logic [1:0][MAX_REQ_COUNT_CHUNK-1:0][3:0]               w_write_req_idx;
     logic [1:0][MAX_REQ_COUNT_CHUNK-1:0]                    w_write_req_valid;
     logic [1:0][MAX_REQ_COUNT_WD-1:0]                       w_write_req_cnt;
-    
+
     logic [DEC_MULTI-1:0][MAX_REQ_COUNT_CHUNK-1:0][3:0]     i_read_req_idx;
     logic [DEC_MULTI-1:0][MAX_REQ_COUNT_CHUNK-1:0]          i_read_req_valid;
     logic [DEC_MULTI-1:0][MAX_REQ_COUNT_WD-1:0]             i_read_req_cnt;
     logic [MAX_REQ_COUNT_WD-1:0]                            w_read_req_cnt_for_wait;
-    
+
     logic [MAX_REQ_COUNT_CHUNK-1:0][3:0]                    r_read_req_idx;
     logic [MAX_REQ_COUNT_CHUNK-1:0]                         r_read_req_valid;
     logic [MAX_REQ_COUNT_WD-1:0]                            r_read_req_cnt;
     logic [1:0][MAX_REQ_COUNT_CHUNK-1:0][3:0]               w_read_req_idx;
     logic [1:0][MAX_REQ_COUNT_CHUNK-1:0]                    w_read_req_valid;
     logic [1:0][MAX_REQ_COUNT_WD-1:0]                       w_read_req_cnt;
-    
+
     logic [DEC_MULTI-1:0][MAX_DATA_COUNT_CHUNK-1:0][3:0]    i_write_data_idx;
     logic [DEC_MULTI-1:0][MAX_DATA_COUNT_CHUNK-1:0]         i_write_data_valid;
     logic [DEC_MULTI-1:0][MAX_DATA_COUNT_WD-1:0]            i_write_data_cnt;
     logic [MAX_DATA_COUNT_WD-1:0]                           w_write0_data_cnt_m1;
     logic [MAX_DATA_COUNT_WD-1:0]                           w_write1_data_cnt_m1;
-    
+
     logic [2:0][MAX_DATA_COUNT_CHUNK-1:0][3:0]              r_write_data_idx;
     logic [2:0][MAX_DATA_COUNT_CHUNK-1:0]                   r_write_data_valid;
     logic [2:0][MAX_DATA_COUNT_WD-1:0]                      r_write_data_cnt;
@@ -193,7 +194,7 @@ module AOU_RX_CORE
     logic [DEC_MULTI+2:0][MAX_DATA_COUNT_CHUNK-1:0]         w_write_data_valid;
     logic [DEC_MULTI+2:0][MAX_DATA_COUNT_WD-1:0]            w_write_data_cnt;
     logic [DEC_MULTI+2:0][MAX_DATA_COUNT_WD-1:0]            w_valid_write_data_cnt;
-    
+
     logic [DEC_MULTI-1:0][MAX_DATA_COUNT_CHUNK-1:0][3:0]    i_read_data_idx;
     logic [DEC_MULTI-1:0][MAX_DATA_COUNT_CHUNK-1:0]         i_read_data_valid;
     logic [DEC_MULTI-1:0][MAX_DATA_COUNT_WD-1:0]            i_read_data_cnt;
@@ -207,18 +208,18 @@ module AOU_RX_CORE
     logic [DEC_MULTI+2:0][MAX_DATA_COUNT_CHUNK-1:0]         w_read_data_valid;
     logic [DEC_MULTI+2:0][MAX_DATA_COUNT_WD-1:0]            w_read_data_cnt;
     logic [DEC_MULTI+2:0][MAX_DATA_COUNT_WD-1:0]            w_valid_read_data_cnt;
-    
+
     logic [DEC_MULTI-1:0][MAX_WR_RESP_COUNT_CHUNK-1:0][3:0] i_write_resp_idx;
     logic [DEC_MULTI-1:0][MAX_WR_RESP_COUNT_CHUNK-1:0]      i_write_resp_valid;
     logic [DEC_MULTI-1:0][MAX_WR_RESP_COUNT_WD-1:0]         i_write_resp_cnt;
-    
+
     logic                                                   w_write512_data_continue;
     logic                                                   w_write1024_data_continue;
     logic                                                   w_read512_data_continue;
     logic                                                   w_read1024_data_continue;
-    
+
     logic [2:0]                                             wait_valid_chunk;
-    
+
     logic                                                   r_write_data_mask;
     logic                                                   r_read_data_mask;
 //-------------------------------------------------------------
@@ -249,20 +250,50 @@ module AOU_RX_CORE
             assign i_msg_credit = w_rx_chunk_data[128*8 +: 16];
         end
     endgenerate
-    
+
 //-------------------------------------------------------------
     always_ff @(posedge I_CLK or negedge I_RESETN) begin
         if (!I_RESETN) begin
             r_aou_rx_phase <= 'd0;
         end else begin
             if(PHY_TYPE != 3) begin
-                if(w_rx_chunk_data_valid) 
+                if(w_rx_chunk_data_valid)
                     r_aou_rx_phase <= r_aou_rx_phase + 1;
             end
         end
     end
-    
+
     assign zero_g = 'd0;
+
+//-----------------------------------------------------------------------
+// Helper functions for selecting fields out of a 12-entry granule chunk
+// (r_g[*]) using a 4-bit stored gid.
+//
+// The stored gid is 4 bits because that is the natural width for a
+// 0..11 granule index, but the array has only 12 entries (`[11:0]`).
+// Using `chunk_g[gid]` directly causes equivalence/synthesis tools to
+// assume the access can address indices 12..15 and inject X for those
+// unreachable lanes, which in turn produces large numbers of "E" key
+// points in Conformal LEC. These helpers express the lookup as an
+// explicit one-hot mux over the 12 in-range entries so the source code
+// never expresses an out-of-range select. The functional behaviour for
+// any in-range gid is identical to a direct array select.
+//-----------------------------------------------------------------------
+    function automatic logic [1:0] f_g_others (input logic [3:0] gid,
+                                               input st_g_packet [11:0] chunk_g);
+        f_g_others = '0;
+        for (int j = 0; j < 12; j++) begin
+            if (gid == j[3:0]) f_g_others = chunk_g[j].others;
+        end
+    endfunction
+
+    function automatic logic [3:0] f_g_msg_type (input logic [3:0] gid,
+                                                 input st_g_packet [11:0] chunk_g);
+        f_g_msg_type = '0;
+        for (int j = 0; j < 12; j++) begin
+            if (gid == j[3:0]) f_g_msg_type = chunk_g[j].msg_type;
+        end
+    endfunction
 
     generate
         if(PHY_TYPE < 2) begin :gen_32_64B
@@ -270,41 +301,41 @@ module AOU_RX_CORE
                 if (!I_RESETN) begin
                     r_fdi_pl_data_valid     <= 'd0;
                     r_g                     <= 'd0;
-    
+
                     r_misc_idx              <= 'd0;
                     r_misc_valid            <= 'd0;
                     r_misc_cnt              <= 'd0;
-    
+
                     r_write_req_idx         <= 'd0;
                     r_write_req_valid       <= 'd0;
                     r_write_req_cnt         <= 'd0;
-    
+
                     r_read_req_idx          <= 'd0;
                     r_read_req_valid        <= 'd0;
                     r_read_req_cnt          <= 'd0;
-    
+
                     r_write_data_idx        <= 'd0;
                     r_write_data_valid      <= 'd0;
                     r_write_data_cnt        <= 'd0;
-                    
+
                     r_read_data_idx         <= 'd0;
                     r_read_data_valid       <= 'd0;
                     r_read_data_cnt         <= 'd0;
-                
+
                     r_write_data_mask       <= 1'b0;
                     r_read_data_mask        <= 1'b0;
                 end else begin
-                        
+
                     if(w_rx_chunk_data_valid) begin
-                        r_misc_idx              <= i_misc_idx[DEC_MULTI-1];  
+                        r_misc_idx              <= i_misc_idx[DEC_MULTI-1];
                         r_misc_valid            <= i_misc_valid[DEC_MULTI-1];
-                        r_misc_cnt              <= i_misc_cnt[DEC_MULTI-1];  
-       
-                        r_write_req_idx         <= i_write_req_idx[DEC_MULTI-1];  
+                        r_misc_cnt              <= i_misc_cnt[DEC_MULTI-1];
+
+                        r_write_req_idx         <= i_write_req_idx[DEC_MULTI-1];
                         r_write_req_valid       <= i_write_req_valid[DEC_MULTI-1];
-                        r_write_req_cnt         <= i_write_req_cnt[DEC_MULTI-1];  
-       
-                        r_read_req_idx          <= i_read_req_idx[DEC_MULTI-1];  
+                        r_write_req_cnt         <= i_write_req_cnt[DEC_MULTI-1];
+
+                        r_read_req_idx          <= i_read_req_idx[DEC_MULTI-1];
                         r_read_req_valid        <= i_read_req_valid[DEC_MULTI-1];
                         r_read_req_cnt          <= i_read_req_cnt[DEC_MULTI-1];
 
@@ -312,20 +343,20 @@ module AOU_RX_CORE
                             r_read_data_mask        <= 'd0;
                         else if(|r_write_data_mask)
                             r_write_data_mask       <= 'd0;
-    
+
                         r_fdi_pl_data_valid     <= {r_fdi_pl_data_valid[1:0], w_rx_chunk_data_valid};
                         r_g                     <= {r_g[1:0], i_g};
-                            
-                        r_write_data_idx        <= {r_write_data_idx[1], r_write_data_idx[0], i_write_data_idx};  
+
+                        r_write_data_idx        <= {r_write_data_idx[1], r_write_data_idx[0], i_write_data_idx};
                         r_write_data_valid      <= {r_write_data_valid[1], r_write_data_valid[0], i_write_data_valid};
-                        r_write_data_cnt        <= {r_write_data_cnt[1], r_write_data_cnt[0], i_write_data_cnt};  
-      
-                        r_read_data_idx         <= {r_read_data_idx[1], r_read_data_idx[0], i_read_data_idx};  
+                        r_write_data_cnt        <= {r_write_data_cnt[1], r_write_data_cnt[0], i_write_data_cnt};
+
+                        r_read_data_idx         <= {r_read_data_idx[1], r_read_data_idx[0], i_read_data_idx};
                         r_read_data_valid       <= {r_read_data_valid[1], r_read_data_valid[0], i_read_data_valid};
-                        r_read_data_cnt         <= {r_read_data_cnt[1], r_read_data_cnt[0], i_read_data_cnt};  
+                        r_read_data_cnt         <= {r_read_data_cnt[1], r_read_data_cnt[0], i_read_data_cnt};
 
                     end else begin
-                        if(w_write512_data_continue | w_read512_data_continue) begin 
+                        if(w_write512_data_continue | w_read512_data_continue) begin
                             r_misc_valid            <= 'd0;
                             r_write_req_valid       <= 'd0;
                             r_read_req_valid        <= 'd0;
@@ -333,54 +364,54 @@ module AOU_RX_CORE
                             r_write_data_valid[2:1] <= 'd0;
                             r_read_data_valid[2:1]  <= 'd0;
 
-                            if(r_write_data_valid[0][0] && (r_g[0][r_write_data_idx[0][0]].others[1:0] == 2'b00))
+                            if(r_write_data_valid[0][0] && (f_g_others(r_write_data_idx[0][0], r_g[0]) == 2'b00))
                                 r_write_data_mask   <= 'd1;
-                            else if(r_read_data_valid[0][0] && (r_g[0][r_read_data_idx[0][0]].others[1:0] == 2'b00))
+                            else if(r_read_data_valid[0][0] && (f_g_others(r_read_data_idx[0][0], r_g[0]) == 2'b00))
                                 r_read_data_mask    <= 'd1;
-                        end else if(w_write1024_data_continue | w_read1024_data_continue) begin  
+                        end else if(w_write1024_data_continue | w_read1024_data_continue) begin
                             r_misc_valid            <= 'd0;
                             r_write_req_valid       <= 'd0;
                             r_read_req_valid        <= 'd0;
                             r_write_data_valid[2]   <= 'd0;
                             r_read_data_valid[2]    <= 'd0;
 
-                            if(r_write_data_valid[0][0] && (r_g[0][r_write_data_idx[0][0]].others[1:0] == 2'b00))
+                            if(r_write_data_valid[0][0] && (f_g_others(r_write_data_idx[0][0], r_g[0]) == 2'b00))
                                 r_write_data_mask       <= 'd1;
-                            else if (r_read_data_valid[0][0] && (r_g[0][r_read_data_idx[0][0]].others[1:0] == 2'b00))
+                            else if (r_read_data_valid[0][0] && (f_g_others(r_read_data_idx[0][0], r_g[0]) == 2'b00))
                                 r_read_data_mask        <= 'd1;
 
-                            if(|r_write_data_valid[0] && (r_g[0][r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)) begin
+                            if(|r_write_data_valid[0] && (f_g_others(r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b10)) begin
                                 r_write_data_valid[1]   <= 'd0;
                                 r_read_data_valid[1]    <= 'd0;
-                            end else if(|r_read_data_valid[0] && (r_g[0][r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)) begin
+                            end else if(|r_read_data_valid[0] && (f_g_others(r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b10)) begin
                                 r_write_data_valid[1]   <= 'd0;
                                 r_read_data_valid[1]    <= 'd0;
                             end
 
                          end else if(wait_valid_chunk == 0) begin
-                            r_misc_idx              <= 'd0;  
+                            r_misc_idx              <= 'd0;
                             r_misc_valid            <= 'd0;
-                            r_misc_cnt              <= 'd0;  
-       
-                            r_write_req_idx         <= 'd0;  
+                            r_misc_cnt              <= 'd0;
+
+                            r_write_req_idx         <= 'd0;
                             r_write_req_valid       <= 'd0;
-                            r_write_req_cnt         <= 'd0;  
-       
-                            r_read_req_idx          <= 'd0;  
+                            r_write_req_cnt         <= 'd0;
+
+                            r_read_req_idx          <= 'd0;
                             r_read_req_valid        <= 'd0;
                             r_read_req_cnt          <= 'd0;
-        
+
                             r_fdi_pl_data_valid     <= {r_fdi_pl_data_valid[1:0], 1'b0};
                             r_g                     <= {r_g[1:0], zero_g};
-       
-                            r_write_data_idx        <= {r_write_data_idx[1], r_write_data_idx[0], {MAX_DATA_COUNT_CHUNK{4'b0}}};  
+
+                            r_write_data_idx        <= {r_write_data_idx[1], r_write_data_idx[0], {MAX_DATA_COUNT_CHUNK{4'b0}}};
                             r_write_data_valid      <= {r_write_data_valid[1], r_write_data_valid[0], {MAX_DATA_COUNT_CHUNK{1'b0}}};
-                            r_write_data_cnt        <= {r_write_data_cnt[1], r_write_data_cnt[0], {MAX_DATA_COUNT_WD{1'b0}}}; 
-    
-                            r_read_data_idx         <= {r_read_data_idx[1], r_read_data_idx[0], {MAX_DATA_COUNT_CHUNK{4'b0}}};  
+                            r_write_data_cnt        <= {r_write_data_cnt[1], r_write_data_cnt[0], {MAX_DATA_COUNT_WD{1'b0}}};
+
+                            r_read_data_idx         <= {r_read_data_idx[1], r_read_data_idx[0], {MAX_DATA_COUNT_CHUNK{4'b0}}};
                             r_read_data_valid       <= {r_read_data_valid[1], r_read_data_valid[0], {MAX_DATA_COUNT_CHUNK{1'b0}}};
-                            r_read_data_cnt         <= {r_read_data_cnt[1], r_read_data_cnt[0], {MAX_DATA_COUNT_WD{1'b0}}}; 
-                         
+                            r_read_data_cnt         <= {r_read_data_cnt[1], r_read_data_cnt[0], {MAX_DATA_COUNT_WD{1'b0}}};
+
                         end
                     end
                 end
@@ -391,41 +422,41 @@ module AOU_RX_CORE
                 if (!I_RESETN) begin
                     r_fdi_pl_data_valid     <= 'd0;
                     r_g                     <= 'd0;
-    
+
                     r_misc_idx              <= 'd0;
                     r_misc_valid            <= 'd0;
                     r_misc_cnt              <= 'd0;
-    
+
                     r_write_req_idx         <= 'd0;
                     r_write_req_valid       <= 'd0;
                     r_write_req_cnt         <= 'd0;
-    
+
                     r_read_req_idx          <= 'd0;
                     r_read_req_valid        <= 'd0;
                     r_read_req_cnt          <= 'd0;
-    
+
                     r_write_data_idx        <= 'd0;
                     r_write_data_valid      <= 'd0;
                     r_write_data_cnt        <= 'd0;
-                    
+
                     r_read_data_idx         <= 'd0;
                     r_read_data_valid       <= 'd0;
                     r_read_data_cnt         <= 'd0;
-                
+
                     r_write_data_mask       <= 1'b0;
                     r_read_data_mask        <= 1'b0;
                 end else begin
-                        
+
                     if(w_rx_chunk_data_valid) begin
-                        r_misc_idx              <= i_misc_idx[DEC_MULTI-1];  
+                        r_misc_idx              <= i_misc_idx[DEC_MULTI-1];
                         r_misc_valid            <= i_misc_valid[DEC_MULTI-1];
-                        r_misc_cnt              <= i_misc_cnt[DEC_MULTI-1];  
-       
-                        r_write_req_idx         <= i_write_req_idx[DEC_MULTI-1];  
+                        r_misc_cnt              <= i_misc_cnt[DEC_MULTI-1];
+
+                        r_write_req_idx         <= i_write_req_idx[DEC_MULTI-1];
                         r_write_req_valid       <= i_write_req_valid[DEC_MULTI-1];
-                        r_write_req_cnt         <= i_write_req_cnt[DEC_MULTI-1];  
-       
-                        r_read_req_idx          <= i_read_req_idx[DEC_MULTI-1];  
+                        r_write_req_cnt         <= i_write_req_cnt[DEC_MULTI-1];
+
+                        r_read_req_idx          <= i_read_req_idx[DEC_MULTI-1];
                         r_read_req_valid        <= i_read_req_valid[DEC_MULTI-1];
                         r_read_req_cnt          <= i_read_req_cnt[DEC_MULTI-1];
 
@@ -433,20 +464,20 @@ module AOU_RX_CORE
                             r_read_data_mask        <= 'd0;
                         else if(|r_write_data_mask)
                             r_write_data_mask       <= 'd0;
-    
+
                         r_fdi_pl_data_valid     <= {r_fdi_pl_data_valid[0], {2{w_rx_chunk_data_valid}}};
                         r_g                     <= {r_g[0], i_g[0], i_g[1]};
-        
-                        r_write_data_idx        <= {r_write_data_idx[0], i_write_data_idx[0], i_write_data_idx[1]};  
+
+                        r_write_data_idx        <= {r_write_data_idx[0], i_write_data_idx[0], i_write_data_idx[1]};
                         r_write_data_valid      <= {r_write_data_valid[0], i_write_data_valid[0], i_write_data_valid[1]};
-                        r_write_data_cnt        <= {r_write_data_cnt[0], i_write_data_cnt[0], i_write_data_cnt[1]};  
-      
-                        r_read_data_idx         <= {r_read_data_idx[0], i_read_data_idx[0], i_read_data_idx[1]};  
+                        r_write_data_cnt        <= {r_write_data_cnt[0], i_write_data_cnt[0], i_write_data_cnt[1]};
+
+                        r_read_data_idx         <= {r_read_data_idx[0], i_read_data_idx[0], i_read_data_idx[1]};
                         r_read_data_valid       <= {r_read_data_valid[0], i_read_data_valid[0], i_read_data_valid[1]};
                         r_read_data_cnt         <= {r_read_data_cnt[0], i_read_data_cnt[0], i_read_data_cnt[1]};
- 
+
                     end else begin
-                        if(w_write512_data_continue | w_read512_data_continue) begin 
+                        if(w_write512_data_continue | w_read512_data_continue) begin
                             r_misc_valid            <= 'd0;
                             r_write_req_valid       <= 'd0;
                             r_read_req_valid        <= 'd0;
@@ -454,95 +485,95 @@ module AOU_RX_CORE
                             r_write_data_valid[2:1] <= 'd0;
                             r_read_data_valid[2:1]  <= 'd0;
 
-                        end else if(w_write1024_data_continue | w_read1024_data_continue) begin  
+                        end else if(w_write1024_data_continue | w_read1024_data_continue) begin
                             r_misc_valid            <= 'd0;
                             r_write_req_valid       <= 'd0;
                             r_read_req_valid        <= 'd0;
                             r_write_data_valid[2]   <= 'd0;
                             r_read_data_valid[2]    <= 'd0;
 
-                            if(r_write_data_valid[0][0] && (r_g[0][r_write_data_idx[0][0]].others[1:0] == 2'b00))
+                            if(r_write_data_valid[0][0] && (f_g_others(r_write_data_idx[0][0], r_g[0]) == 2'b00))
                                 r_write_data_mask       <= 'd1;
-                            else if (r_read_data_valid[0][0] && (r_g[0][r_read_data_idx[0][0]].others[1:0] == 2'b00))
+                            else if (r_read_data_valid[0][0] && (f_g_others(r_read_data_idx[0][0], r_g[0]) == 2'b00))
                                 r_read_data_mask        <= 'd1;
 
-                            if(|r_write_data_valid[0] && (r_g[0][r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)) begin
+                            if(|r_write_data_valid[0] && (f_g_others(r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b10)) begin
                                 r_write_data_valid[1] <= 'd0;
                                 r_read_data_valid[1]  <= 'd0;
-                            end else if(|r_read_data_valid[0] && (r_g[0][r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)) begin
+                            end else if(|r_read_data_valid[0] && (f_g_others(r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b10)) begin
                                 r_write_data_valid[1] <= 'd0;
                                 r_read_data_valid[1]  <= 'd0;
                             end
 
                         end else if(wait_valid_chunk == 0) begin
-                            r_misc_idx              <= 'd0;  
+                            r_misc_idx              <= 'd0;
                             r_misc_valid            <= 'd0;
-                            r_misc_cnt              <= 'd0;  
-       
-                            r_write_req_idx         <= 'd0;  
+                            r_misc_cnt              <= 'd0;
+
+                            r_write_req_idx         <= 'd0;
                             r_write_req_valid       <= 'd0;
-                            r_write_req_cnt         <= 'd0;  
-       
-                            r_read_req_idx          <= 'd0;  
+                            r_write_req_cnt         <= 'd0;
+
+                            r_read_req_idx          <= 'd0;
                             r_read_req_valid        <= 'd0;
                             r_read_req_cnt          <= 'd0;
 
                             r_fdi_pl_data_valid     <= {r_fdi_pl_data_valid[0], 2'b0};
                             r_g                     <= {r_g[0], {2{zero_g}}};
-                
-                            r_write_data_idx        <= {r_write_data_idx[0], {MAX_DATA_COUNT_CHUNK{4'b0}}, {MAX_DATA_COUNT_CHUNK{4'b0}}};  
+
+                            r_write_data_idx        <= {r_write_data_idx[0], {MAX_DATA_COUNT_CHUNK{4'b0}}, {MAX_DATA_COUNT_CHUNK{4'b0}}};
                             r_write_data_valid      <= {r_write_data_valid[0], {MAX_DATA_COUNT_CHUNK{1'b0}}, {MAX_DATA_COUNT_CHUNK{1'b0}}};
-                            r_write_data_cnt        <= {r_write_data_cnt[0], {MAX_DATA_COUNT_WD{1'b0}}, {MAX_DATA_COUNT_WD{1'b0}}}; 
-    
-                            r_read_data_idx         <= {r_read_data_idx[0], {MAX_DATA_COUNT_CHUNK{4'b0}}, {MAX_DATA_COUNT_CHUNK{4'b0}}};  
+                            r_write_data_cnt        <= {r_write_data_cnt[0], {MAX_DATA_COUNT_WD{1'b0}}, {MAX_DATA_COUNT_WD{1'b0}}};
+
+                            r_read_data_idx         <= {r_read_data_idx[0], {MAX_DATA_COUNT_CHUNK{4'b0}}, {MAX_DATA_COUNT_CHUNK{4'b0}}};
                             r_read_data_valid       <= {r_read_data_valid[0], {MAX_DATA_COUNT_CHUNK{1'b0}}, {MAX_DATA_COUNT_CHUNK{1'b0}}};
                             r_read_data_cnt         <= {r_read_data_cnt[0], {MAX_DATA_COUNT_WD{1'b0}}, {MAX_DATA_COUNT_WD{1'b0}}};
- 
+
                         end
                     end
                 end
             end
-        
+
         end else begin :gen_256B
             always_ff @(posedge I_CLK or negedge I_RESETN) begin
                 if (!I_RESETN) begin
                     r_fdi_pl_data_valid     <= 'd0;
                     r_g                     <= 'd0;
-    
+
                     r_misc_idx              <= 'd0;
                     r_misc_valid            <= 'd0;
                     r_misc_cnt              <= 'd0;
-    
+
                     r_write_req_idx         <= 'd0;
                     r_write_req_valid       <= 'd0;
                     r_write_req_cnt         <= 'd0;
-    
+
                     r_read_req_idx          <= 'd0;
                     r_read_req_valid        <= 'd0;
                     r_read_req_cnt          <= 'd0;
-    
+
                     r_write_data_idx        <= 'd0;
                     r_write_data_valid      <= 'd0;
                     r_write_data_cnt        <= 'd0;
-                    
+
                     r_read_data_idx         <= 'd0;
                     r_read_data_valid       <= 'd0;
                     r_read_data_cnt         <= 'd0;
-                
+
                     r_write_data_mask       <= 1'b0;
                     r_read_data_mask        <= 1'b0;
                 end else begin
-                        
+
                     if(w_rx_chunk_data_valid) begin
-                        r_misc_idx              <= i_misc_idx[DEC_MULTI-1];  
+                        r_misc_idx              <= i_misc_idx[DEC_MULTI-1];
                         r_misc_valid            <= i_misc_valid[DEC_MULTI-1];
-                        r_misc_cnt              <= i_misc_cnt[DEC_MULTI-1];  
-       
-                        r_write_req_idx         <= i_write_req_idx[DEC_MULTI-1];  
+                        r_misc_cnt              <= i_misc_cnt[DEC_MULTI-1];
+
+                        r_write_req_idx         <= i_write_req_idx[DEC_MULTI-1];
                         r_write_req_valid       <= i_write_req_valid[DEC_MULTI-1];
-                        r_write_req_cnt         <= i_write_req_cnt[DEC_MULTI-1];  
-       
-                        r_read_req_idx          <= i_read_req_idx[DEC_MULTI-1];  
+                        r_write_req_cnt         <= i_write_req_cnt[DEC_MULTI-1];
+
+                        r_read_req_idx          <= i_read_req_idx[DEC_MULTI-1];
                         r_read_req_valid        <= i_read_req_valid[DEC_MULTI-1];
                         r_read_req_cnt          <= i_read_req_cnt[DEC_MULTI-1];
 
@@ -550,35 +581,35 @@ module AOU_RX_CORE
                             r_read_data_mask        <= 'd0;
                         else if(|r_write_data_mask)
                             r_write_data_mask       <= 'd0;
-                
+
                         r_fdi_pl_data_valid     <= {3{w_rx_chunk_data_valid}};
                         r_g                     <= {i_g[1], i_g[2], i_g[3]};
-    
-                        r_write_data_idx        <= {i_write_data_idx[1], i_write_data_idx[2], i_write_data_idx[3]};  
+
+                        r_write_data_idx        <= {i_write_data_idx[1], i_write_data_idx[2], i_write_data_idx[3]};
                         r_write_data_valid      <= {i_write_data_valid[1], i_write_data_valid[2], i_write_data_valid[3]};
-                        r_write_data_cnt        <= {i_write_data_cnt[1], i_write_data_cnt[2], i_write_data_cnt[3]};  
-      
-                        r_read_data_idx         <= {i_read_data_idx[1], i_read_data_idx[2], i_read_data_idx[3]};  
+                        r_write_data_cnt        <= {i_write_data_cnt[1], i_write_data_cnt[2], i_write_data_cnt[3]};
+
+                        r_read_data_idx         <= {i_read_data_idx[1], i_read_data_idx[2], i_read_data_idx[3]};
                         r_read_data_valid       <= {i_read_data_valid[1], i_read_data_valid[2], i_read_data_valid[3]};
                         r_read_data_cnt         <= {i_read_data_cnt[1], i_read_data_cnt[2], i_read_data_cnt[3]};
-                    
+
                     end else begin
                         if(wait_valid_chunk == 0) begin
-                            r_misc_idx              <= 'd0;  
+                            r_misc_idx              <= 'd0;
                             r_misc_valid            <= 'd0;
-                            r_misc_cnt              <= 'd0;  
-       
-                            r_write_req_idx         <= 'd0;  
+                            r_misc_cnt              <= 'd0;
+
+                            r_write_req_idx         <= 'd0;
                             r_write_req_valid       <= 'd0;
-                            r_write_req_cnt         <= 'd0;  
-       
-                            r_read_req_idx          <= 'd0;  
+                            r_write_req_cnt         <= 'd0;
+
+                            r_read_req_idx          <= 'd0;
                             r_read_req_valid        <= 'd0;
                             r_read_req_cnt          <= 'd0;
 
                             r_fdi_pl_data_valid     <= 'd0;
                             r_g                     <= 'd0;
-              
+
                             r_write_data_idx        <= 'd0;
                             r_write_data_valid      <= 'd0;
                             r_write_data_cnt        <= 'd0;
@@ -592,11 +623,11 @@ module AOU_RX_CORE
             end
         end
     endgenerate
-    
+
 //-------------------------------------------------------------
     genvar i, j;
     generate
-        for(j = 0; j < DEC_MULTI; j = j + 1) begin: gen_message_decode_per_chunk 
+        for(j = 0; j < DEC_MULTI; j = j + 1) begin: gen_message_decode_per_chunk
             for (i = 0; i < 12; i = i + 1) begin : gen_message_decode
                 assign i_misc_start[j][i]          = i_msg_start[j][i] & (i_g[j][i].msg_type == MSG_MISC);
                 assign i_write_req_start[j][i]     = i_msg_start[j][i] & (i_g[j][i].msg_type == MSG_WR_REQ);
@@ -607,13 +638,13 @@ module AOU_RX_CORE
             end
         end
     endgenerate
-        
+
     assign w_g                  = {i_g, r_g[0], r_g[1], r_g[2]};
 
     assign w_misc_idx           = {i_misc_idx[0], r_misc_idx};
     assign w_misc_valid         = {(i_misc_valid[0] & {MAX_MISC_COUNT_CHUNK{w_rx_chunk_data_valid}}), r_misc_valid};
     assign w_misc_cnt           = {i_misc_cnt[0], r_misc_cnt};
-    
+
     assign w_write_req_idx      = {i_write_req_idx[0], r_write_req_idx};
     assign w_write_req_valid    = {(i_write_req_valid[0] & {MAX_REQ_COUNT_CHUNK{w_rx_chunk_data_valid}}) , r_write_req_valid};
     assign w_write_req_cnt      = {i_write_req_cnt[0], r_write_req_cnt};
@@ -629,7 +660,7 @@ module AOU_RX_CORE
     assign w_read_data_idx      = {i_read_data_idx, r_read_data_idx[0], r_read_data_idx[1], r_read_data_idx[2]};
     assign w_read_data_valid    = {(i_read_data_valid & {MAX_DATA_COUNT_CHUNK{w_rx_chunk_data_valid}}), r_read_data_valid[0], r_read_data_valid[1], r_read_data_valid[2]};
     assign w_read_data_cnt      = {i_read_data_cnt, r_read_data_cnt[0], r_read_data_cnt[1], r_read_data_cnt[2]};
- 
+
 //Find start index for each message (misc, aw, ar, w, b, r)
 //-------------------------------------------------------------
     integer idx_misc;
@@ -638,7 +669,7 @@ module AOU_RX_CORE
         i_misc_cnt     = 'd0;
         i_misc_valid   = 'd0;
         i_misc_idx     = 'd0;
-        for(idx_dec_misc = 0; idx_dec_misc < DEC_MULTI; idx_dec_misc = idx_dec_misc + 1) begin  
+        for(idx_dec_misc = 0; idx_dec_misc < DEC_MULTI; idx_dec_misc = idx_dec_misc + 1) begin
             for(idx_misc = 0; idx_misc < 12; idx_misc = idx_misc + 1) begin
                 if(i_misc_start[idx_dec_misc][idx_misc] == 1'b1) begin
                     if (i_misc_cnt[idx_dec_misc] < MAX_MISC_COUNT_CHUNK) begin
@@ -650,7 +681,7 @@ module AOU_RX_CORE
             end
         end
     end
-    
+
 //-------------------------------------------------------------
     integer idx_wr_req;
     integer idx_dec_wr_req;
@@ -670,7 +701,7 @@ module AOU_RX_CORE
             end
         end
     end
-    
+
 //-------------------------------------------------------------
     integer idx_rd_req;
     integer idx_dec_rd_req;
@@ -690,7 +721,7 @@ module AOU_RX_CORE
             end
         end
     end
-    
+
 //-------------------------------------------------------------
     integer idx_wr_data;
     integer idx_dec_wr_data;
@@ -705,32 +736,32 @@ module AOU_RX_CORE
                         i_write_data_idx[idx_dec_wr_data][i_write_data_cnt[idx_dec_wr_data][MAX_DATA_WD-1:0]] = idx_wr_data;
                         i_write_data_valid[idx_dec_wr_data][i_write_data_cnt[idx_dec_wr_data][MAX_DATA_WD-1:0]] = 1'b1;
                         i_write_data_cnt[idx_dec_wr_data] = i_write_data_cnt[idx_dec_wr_data] + 1;
-                    end 
+                    end
                 end
             end
         end
     end
-    
+
     assign w_write0_data_cnt_m1 = (r_write_data_cnt[0] == 0) ? 0 : (r_write_data_cnt[0] -1);
     assign w_write1_data_cnt_m1 = (r_write_data_cnt[1] == 0) ? 0 : (r_write_data_cnt[1] -1);
-    
+
     always_comb begin
         w_write512_data_continue = 1'b0;
         w_write1024_data_continue = 1'b0;
         if(PHY_TYPE < 2) begin
-            if(|r_write_data_valid[0]) begin 
-                if(r_g[0][r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b01)
+            if(|r_write_data_valid[0]) begin
+                if(f_g_others(r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b01)
                     w_write512_data_continue = 1'b1;
-                else if(r_g[0][r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)
+                else if(f_g_others(r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b10)
                     w_write1024_data_continue = 1'b1;
             end
             if(|r_write_data_valid[1]) begin
-                if(r_g[1][r_write_data_idx[1][w_write1_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)
+                if(f_g_others(r_write_data_idx[1][w_write1_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[1]) == 2'b10)
                     w_write1024_data_continue = 1'b1;
             end
         end else if(PHY_TYPE == 2) begin
             if(|r_write_data_valid[0]) begin
-                if(r_g[0][r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)
+                if(f_g_others(r_write_data_idx[0][w_write0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b10)
                     w_write1024_data_continue = 1'b1;
             end
         end
@@ -755,32 +786,32 @@ module AOU_RX_CORE
             end
         end
     end
-    
+
     assign w_read0_data_cnt_m1 = (r_read_data_cnt[0] == 0) ? 0 : (r_read_data_cnt[0] -1);
     assign w_read1_data_cnt_m1 = (r_read_data_cnt[1] == 0) ? 0 : (r_read_data_cnt[1] -1);
-    
+
     always_comb begin
         w_read512_data_continue = 1'b0;
         w_read1024_data_continue = 1'b0;
         if(PHY_TYPE < 2) begin
             if(|r_read_data_valid[0]) begin
-                if(r_g[0][r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b01)
+                if(f_g_others(r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b01)
                     w_read512_data_continue = 1'b1;
-                else if(r_g[0][r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)
+                else if(f_g_others(r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b10)
                     w_read1024_data_continue = 1'b1;
             end
             if(|r_read_data_valid[1]) begin
-                if(r_g[1][r_read_data_idx[1][w_read1_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)                
+                if(f_g_others(r_read_data_idx[1][w_read1_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[1]) == 2'b10)
                     w_read1024_data_continue = 1'b1;
             end
         end else if(PHY_TYPE == 2) begin
             if(|r_read_data_valid[0]) begin
-                if(r_g[0][r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)
+                if(f_g_others(r_read_data_idx[0][w_read0_data_cnt_m1[MAX_DATA_WD-1:0]], r_g[0]) == 2'b10)
                     w_read1024_data_continue = 1'b1;
             end
         end
     end
-     
+
 //-------------------------------------------------------------
     integer idx_wr_resp;
     integer idx_dec_wr_resp;
@@ -800,7 +831,7 @@ module AOU_RX_CORE
             end
         end
     end
-    
+
 //-------------------------------------------------------------
     assign w_misc_cnt_for_wait          = (r_misc_cnt == 0) ? 0 : (r_misc_cnt -1);
     assign w_write_req_cnt_for_wait     = (r_write_req_cnt == 0) ? 0 : (r_write_req_cnt -1);
@@ -813,31 +844,57 @@ module AOU_RX_CORE
             w_valid_read_data_cnt[data_dec_sel] = (w_read_data_cnt[data_dec_sel] == 0) ? 0 : (w_read_data_cnt[data_dec_sel] -1);
         end
     end
-    
-    assign wait_valid_chunk[2] = ((r_write_data_valid[2][w_valid_write_data_cnt[0][MAX_DATA_WD-1:0]] && (r_g[2][r_write_data_idx[2][w_valid_write_data_cnt[0][MAX_DATA_WD-1:0]]].others[1:0] == 2'b10) && (((r_g[2][r_write_data_idx[2][w_valid_write_data_cnt[0][MAX_DATA_WD-1:0]]].msg_type == MSG_WR_DATA) && (r_write_data_idx[2][w_valid_write_data_cnt[0][MAX_DATA_WD-1:0]] + 30 > 36)) |               
-                                                                                                                                                                                                          ((r_g[2][r_write_data_idx[2][w_valid_write_data_cnt[0][MAX_DATA_WD-1:0]]].msg_type == MSG_WRF_DATA) && (r_write_data_idx[2][w_valid_write_data_cnt[0][MAX_DATA_WD-1:0]] + 27 > 36)))) ||                                                                                                                                                                                                                   
-                                 (r_read_data_valid[2][w_valid_read_data_cnt[0][MAX_DATA_WD-1:0]] && (r_g[2][r_read_data_idx[2][w_valid_read_data_cnt[0][MAX_DATA_WD-1:0]]].others[1:0] == 2'b10) && (r_read_data_idx[2][w_valid_read_data_cnt[0][MAX_DATA_WD-1:0]] + 27 > 36))) ||
-                                 ((PHY_TYPE > 1) && ((r_write_data_valid[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]] && (r_g[1][r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]]].others[1:0] == 2'b10) && ((r_g[1][r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]]].msg_type == MSG_WR_DATA) |               
-                                                                                                                                                                                                                             (r_g[1][r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]]].msg_type == MSG_WRF_DATA))) ||                                                                                                                                                                                                                   
-                                                    (r_read_data_valid[1][w_valid_read_data_cnt[1][MAX_DATA_WD-1:0]] && (r_g[1][r_read_data_idx[1][w_valid_read_data_cnt[1][MAX_DATA_WD-1:0]]].others[1:0] == 2'b10)))) ||
-                                 ((PHY_TYPE == 3) && ((r_write_data_valid[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]] && (r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].others[1:0] == 2'b10) && ((r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].msg_type == MSG_WR_DATA) |               
-                                                                                                                                                                                                                              (r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].msg_type == MSG_WRF_DATA))) ||                                                                                                                                                                                                                   
-                                                     (r_read_data_valid[0][w_valid_read_data_cnt[2][MAX_DATA_WD-1:0]] && (r_g[0][r_read_data_idx[0][w_valid_read_data_cnt[2][MAX_DATA_WD-1:0]]].others[1:0] == 2'b10))));
- 
-    assign wait_valid_chunk[1] = ((r_write_data_valid[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]] && (r_g[1][r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]]].others[1:0] == 2'b01) && (((r_g[1][r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]]].msg_type == MSG_WR_DATA) && (r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]] + 15 > 24)) | 
-                                                                                                                                                                                                          ((r_g[1][r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]]].msg_type == MSG_WRF_DATA) && (r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]] + 14 > 24)))) ||
-                                 (r_read_data_valid[1][w_valid_read_data_cnt[1][MAX_DATA_WD-1:0]] && (r_g[1][r_read_data_idx[1][w_valid_read_data_cnt[1][MAX_DATA_WD-1:0]]].others[1:0] == 2'b01) && (r_read_data_idx[1][w_valid_read_data_cnt[1][MAX_DATA_WD-1:0]] + 14 > 24))) ||
-                                 ((PHY_TYPE > 1) && ((r_write_data_valid[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]] && (r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].others[1:0] == 2'b01) && ((r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].msg_type == MSG_WR_DATA) |
-                                                                                                                                                                                                                             (r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].msg_type == MSG_WRF_DATA))) ||
-                                                    (r_read_data_valid[0][w_valid_read_data_cnt[2][MAX_DATA_WD-1:0]] && (r_g[0][r_read_data_idx[0][w_valid_read_data_cnt[2][MAX_DATA_WD-1:0]]].others[1:0] == 2'b01))));
- 
-    assign wait_valid_chunk[0] = ((|r_misc_valid && (r_g[0][r_misc_idx[w_misc_cnt_for_wait[MAX_MISC_WD-1:0]]].others[0] == 1'b1) && (r_misc_idx[w_misc_cnt_for_wait[MAX_MISC_WD-1:0]] + 2 > 12)) |
-                                  (|r_write_req_valid && (r_write_req_idx[w_write_req_cnt_for_wait[MAX_REQ_WD-1:0]] + 3 > 12)) | 
-                                  (|r_read_req_valid && (r_read_req_idx[w_read_req_cnt_for_wait[MAX_REQ_WD-1:0]] + 3 > 12)) | 
-                                  (|r_write_data_valid[0] && (r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].others[1:0] == 2'b00) && (((r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].msg_type == MSG_WR_DATA) && (r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]+ 8 > 12)) |
-                                                                                                                                                               ((r_g[0][r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]].msg_type == MSG_WRF_DATA) && (r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]]+ 7 > 12))) ) |
-                                  (|r_read_data_valid[0] && (r_g[0][r_read_data_idx[0][w_valid_read_data_cnt[2][MAX_DATA_WD-1:0]]].others[1:0] == 2'b00) && (r_read_data_idx[0][w_valid_read_data_cnt[2][MAX_DATA_WD-1:0]]+ 8 > 12)));
-    
+
+    // Pre-resolve the per-chunk granule indices used by wait_valid_chunk so
+    // each f_g_*() helper invocation stays narrow and readable. The slot
+    // indices (e.g. w_valid_*_data_cnt[k][MAX_DATA_WD-1:0]) are already in
+    // range for the data_idx arrays; the X-injection problem we are fixing
+    // is on the outer r_g[X][gid] select, which is what the helpers absorb.
+    logic [3:0] w_wvc_wridx_c2;
+    logic [3:0] w_wvc_rdidx_c2;
+    logic [3:0] w_wvc_wridx_c1;
+    logic [3:0] w_wvc_rdidx_c1;
+    logic [3:0] w_wvc_wridx_c0;
+    logic [3:0] w_wvc_rdidx_c0;
+    logic [3:0] w_wvc_misc_idx;
+    // Pre-resolve the misc-chunk granule "others" lookup into a wire because
+    // the Conformal LEC parser does not accept a bit-select directly on a
+    // function call result (e.g. f_g_others(...)[0]).
+    logic [1:0] w_wvc_misc_others;
+
+    assign w_wvc_wridx_c2 = r_write_data_idx[2][w_valid_write_data_cnt[0][MAX_DATA_WD-1:0]];
+    assign w_wvc_rdidx_c2 = r_read_data_idx [2][w_valid_read_data_cnt [0][MAX_DATA_WD-1:0]];
+    assign w_wvc_wridx_c1 = r_write_data_idx[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]];
+    assign w_wvc_rdidx_c1 = r_read_data_idx [1][w_valid_read_data_cnt [1][MAX_DATA_WD-1:0]];
+    assign w_wvc_wridx_c0 = r_write_data_idx[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]];
+    assign w_wvc_rdidx_c0 = r_read_data_idx [0][w_valid_read_data_cnt [2][MAX_DATA_WD-1:0]];
+    assign w_wvc_misc_idx = r_misc_idx[w_misc_cnt_for_wait[MAX_MISC_WD-1:0]];
+    assign w_wvc_misc_others = f_g_others(w_wvc_misc_idx, r_g[0]);
+
+    assign wait_valid_chunk[2] = ((r_write_data_valid[2][w_valid_write_data_cnt[0][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_wridx_c2, r_g[2]) == 2'b10) && (((f_g_msg_type(w_wvc_wridx_c2, r_g[2]) == MSG_WR_DATA) && (w_wvc_wridx_c2 + 30 > 36)) |
+                                                                                                                                                          ((f_g_msg_type(w_wvc_wridx_c2, r_g[2]) == MSG_WRF_DATA) && (w_wvc_wridx_c2 + 27 > 36)))) ||
+                                 (r_read_data_valid[2][w_valid_read_data_cnt[0][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_rdidx_c2, r_g[2]) == 2'b10) && (w_wvc_rdidx_c2 + 27 > 36))) ||
+                                 ((PHY_TYPE > 1) && ((r_write_data_valid[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_wridx_c1, r_g[1]) == 2'b10) && ((f_g_msg_type(w_wvc_wridx_c1, r_g[1]) == MSG_WR_DATA) |
+                                                                                                                                                                            (f_g_msg_type(w_wvc_wridx_c1, r_g[1]) == MSG_WRF_DATA))) ||
+                                                    (r_read_data_valid[1][w_valid_read_data_cnt[1][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_rdidx_c1, r_g[1]) == 2'b10)))) ||
+                                 ((PHY_TYPE == 3) && ((r_write_data_valid[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_wridx_c0, r_g[0]) == 2'b10) && ((f_g_msg_type(w_wvc_wridx_c0, r_g[0]) == MSG_WR_DATA) |
+                                                                                                                                                                              (f_g_msg_type(w_wvc_wridx_c0, r_g[0]) == MSG_WRF_DATA))) ||
+                                                     (r_read_data_valid[0][w_valid_read_data_cnt[2][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_rdidx_c0, r_g[0]) == 2'b10))));
+
+    assign wait_valid_chunk[1] = ((r_write_data_valid[1][w_valid_write_data_cnt[1][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_wridx_c1, r_g[1]) == 2'b01) && (((f_g_msg_type(w_wvc_wridx_c1, r_g[1]) == MSG_WR_DATA) && (w_wvc_wridx_c1 + 15 > 24)) |
+                                                                                                                                                          ((f_g_msg_type(w_wvc_wridx_c1, r_g[1]) == MSG_WRF_DATA) && (w_wvc_wridx_c1 + 14 > 24)))) ||
+                                 (r_read_data_valid[1][w_valid_read_data_cnt[1][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_rdidx_c1, r_g[1]) == 2'b01) && (w_wvc_rdidx_c1 + 14 > 24))) ||
+                                 ((PHY_TYPE > 1) && ((r_write_data_valid[0][w_valid_write_data_cnt[2][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_wridx_c0, r_g[0]) == 2'b01) && ((f_g_msg_type(w_wvc_wridx_c0, r_g[0]) == MSG_WR_DATA) |
+                                                                                                                                                                            (f_g_msg_type(w_wvc_wridx_c0, r_g[0]) == MSG_WRF_DATA))) ||
+                                                    (r_read_data_valid[0][w_valid_read_data_cnt[2][MAX_DATA_WD-1:0]] && (f_g_others(w_wvc_rdidx_c0, r_g[0]) == 2'b01))));
+
+    assign wait_valid_chunk[0] = ((|r_misc_valid && (w_wvc_misc_others[0] == 1'b1) && (w_wvc_misc_idx + 2 > 12)) |
+                                  (|r_write_req_valid && (r_write_req_idx[w_write_req_cnt_for_wait[MAX_REQ_WD-1:0]] + 3 > 12)) |
+                                  (|r_read_req_valid && (r_read_req_idx[w_read_req_cnt_for_wait[MAX_REQ_WD-1:0]] + 3 > 12)) |
+                                  (|r_write_data_valid[0] && (f_g_others(w_wvc_wridx_c0, r_g[0]) == 2'b00) && (((f_g_msg_type(w_wvc_wridx_c0, r_g[0]) == MSG_WR_DATA) && (w_wvc_wridx_c0 + 8 > 12)) |
+                                                                                                              ((f_g_msg_type(w_wvc_wridx_c0, r_g[0]) == MSG_WRF_DATA) && (w_wvc_wridx_c0 + 7 > 12))) ) |
+                                  (|r_read_data_valid[0] && (f_g_others(w_wvc_rdidx_c0, r_g[0]) == 2'b00) && (w_wvc_rdidx_c0 + 8 > 12)));
+
 //-------------------------------------------------------------
     st_misc_grantcredit_packet      [DEC_MULTI-1:0][MAX_MISC_COUNT_CHUNK-1:0]       w_misc_packet               ;
     st_misc_activation_packet                                                       w_misc_activation_packet    ;
@@ -850,28 +907,28 @@ module AOU_RX_CORE
     st_read_data512_packet_tmp      [DEC_MULTI-1:0]                                 w_read_data512_packet_tmp   ;
     st_read_data1024_packet_tmp     [DEC_MULTI-1:0]                                 w_read_data1024_packet_tmp  ;
     st_write_resp_packet_tmp        [DEC_MULTI-1:0][MAX_WR_RESP_COUNT_CHUNK-1:0]    w_write_resp_packet_tmp     ;
-    
+
     integer idx_msg_sel, idx_dec_sel;
     always_comb begin
         for(idx_dec_sel = 0; idx_dec_sel < DEC_MULTI; idx_dec_sel = idx_dec_sel + 1) begin
             for(idx_msg_sel = 0; idx_msg_sel < MAX_MISC_COUNT_CHUNK; idx_msg_sel = idx_msg_sel + 1) begin
                 w_misc_packet[idx_dec_sel][idx_msg_sel] = w_g[(idx_dec_sel*12 + w_misc_idx[idx_dec_sel][idx_msg_sel] + 24) +: 2];
             end
-   
-            for(idx_msg_sel = 0; idx_msg_sel < MAX_REQ_COUNT_CHUNK; idx_msg_sel = idx_msg_sel + 1) begin 
+
+            for(idx_msg_sel = 0; idx_msg_sel < MAX_REQ_COUNT_CHUNK; idx_msg_sel = idx_msg_sel + 1) begin
                 w_write_req_packet_tmp[idx_dec_sel][idx_msg_sel] = w_g[(idx_dec_sel*12 + w_write_req_idx[idx_dec_sel][idx_msg_sel] + 24) +: 3];
                 w_read_req_packet_tmp[idx_dec_sel][idx_msg_sel] = w_g[(idx_dec_sel*12 + w_read_req_idx[idx_dec_sel][idx_msg_sel] + 24) +: 3];
             end
-    
-            for(idx_msg_sel = 0; idx_msg_sel < MAX_DATA_COUNT_CHUNK; idx_msg_sel = idx_msg_sel + 1) begin        
+
+            for(idx_msg_sel = 0; idx_msg_sel < MAX_DATA_COUNT_CHUNK; idx_msg_sel = idx_msg_sel + 1) begin
                 if(w_g[(2+idx_dec_sel)*12 + w_write_data_idx[2+idx_dec_sel][idx_msg_sel]].msg_type == MSG_WR_DATA)
                     w_write_data256_packet_tmp[idx_dec_sel][idx_msg_sel] = w_g[(idx_dec_sel*12 + w_write_data_idx[2+idx_dec_sel][idx_msg_sel] + 24) +: 8];
                 else
-                    w_write_data256_packet_tmp[idx_dec_sel][idx_msg_sel] = w_g[(idx_dec_sel*12 + w_write_data_idx[2+idx_dec_sel][idx_msg_sel] + 24) +: 7];              
- 
-                w_read_data256_packet_tmp[idx_dec_sel][idx_msg_sel] = w_g[(idx_dec_sel*12 + w_read_data_idx[2+idx_dec_sel][idx_msg_sel] + 24) +: 8];       
+                    w_write_data256_packet_tmp[idx_dec_sel][idx_msg_sel] = w_g[(idx_dec_sel*12 + w_write_data_idx[2+idx_dec_sel][idx_msg_sel] + 24) +: 7];
+
+                w_read_data256_packet_tmp[idx_dec_sel][idx_msg_sel] = w_g[(idx_dec_sel*12 + w_read_data_idx[2+idx_dec_sel][idx_msg_sel] + 24) +: 8];
             end
-        
+
             if(w_g[(1+idx_dec_sel)*12 + w_write_data_idx[1+idx_dec_sel][w_valid_write_data_cnt[1+idx_dec_sel][MAX_DATA_WD-1:0]]].msg_type == MSG_WR_DATA)
                 w_write_data512_packet_tmp[idx_dec_sel] = w_g[(idx_dec_sel*12 + w_write_data_idx[1+idx_dec_sel][w_valid_write_data_cnt[1+idx_dec_sel][MAX_DATA_WD-1:0]] + 12) +: 15];
             else
@@ -881,10 +938,10 @@ module AOU_RX_CORE
                 w_write_data1024_packet_tmp[idx_dec_sel] = w_g[(idx_dec_sel*12 + w_write_data_idx[idx_dec_sel][w_valid_write_data_cnt[idx_dec_sel][MAX_DATA_WD-1:0]]) +: 30];
             else
                 w_write_data1024_packet_tmp[idx_dec_sel] = w_g[(idx_dec_sel*12 + w_write_data_idx[idx_dec_sel][w_valid_write_data_cnt[idx_dec_sel][MAX_DATA_WD-1:0]]) +: 27];
-        
+
             w_read_data512_packet_tmp[idx_dec_sel] = w_g[(idx_dec_sel*12 + w_read_data_idx[1+idx_dec_sel][w_valid_read_data_cnt[1+idx_dec_sel][MAX_DATA_WD-1:0]] + 12) +: 14];
             w_read_data1024_packet_tmp[idx_dec_sel] = w_g[(idx_dec_sel*12 + w_read_data_idx[idx_dec_sel][w_valid_read_data_cnt[idx_dec_sel][MAX_DATA_WD-1:0]]) +: 27];
-        
+
             for(idx_msg_sel = 0; idx_msg_sel < MAX_WR_RESP_COUNT_CHUNK; idx_msg_sel = idx_msg_sel + 1) begin
                 w_write_resp_packet_tmp[idx_dec_sel][idx_msg_sel]        = w_g[(idx_dec_sel*12 + i_write_resp_idx[idx_dec_sel][idx_msg_sel]+36) +: 1];
             end
@@ -902,7 +959,7 @@ module AOU_RX_CORE
     st_read_data512_packet      [DEC_MULTI-1:0]                                 w_read_data512_packet       ;
     st_read_data1024_packet     [DEC_MULTI-1:0]                                 w_read_data1024_packet      ;
     st_write_resp_packet        [DEC_MULTI-1:0][MAX_WR_RESP_COUNT_CHUNK-1:0]    w_write_resp_packet         ;
-    
+
     logic [DEC_MULTI-1:0][MAX_REQ_COUNT_CHUNK-1:0][63:0]        awaddr_flat;
     logic [DEC_MULTI-1:0][MAX_REQ_COUNT_CHUNK-1:0][63:0]        araddr_flat;
     logic [DEC_MULTI-1:0][MAX_DATA_COUNT_CHUNK-1:0][255:0]      wdata_256_flat;
@@ -914,14 +971,14 @@ module AOU_RX_CORE
     logic [DEC_MULTI-1:0][MAX_DATA_COUNT_CHUNK-1:0][255:0]      rdata_256_flat;
     logic [DEC_MULTI-1:0][511:0]                                rdata_512_flat;
     logic [DEC_MULTI-1:0][1023:0]                               rdata_1024_flat;
-    
-    
+
+
     always_comb begin
         for(int unsigned k = 0; k < DEC_MULTI; k = k + 1) begin
             for(int unsigned j = 0; j < MAX_REQ_COUNT_CHUNK; j = j + 1) begin
                 for(int unsigned i = 0; i < 8 ; i = i+1) begin
                     awaddr_flat[k][j][(i+1)*8-1 -: 8] = w_write_req_packet_tmp[k][j].awaddr[i];
-                    araddr_flat[k][j][(i+1)*8-1 -: 8] = w_read_req_packet_tmp[k][j].araddr[i];            
+                    araddr_flat[k][j][(i+1)*8-1 -: 8] = w_read_req_packet_tmp[k][j].araddr[i];
                 end
             end
 
@@ -931,32 +988,32 @@ module AOU_RX_CORE
                 end
                 for(int unsigned i = 0; i < 32; i = i + 1) begin
                     wdata_256_flat[k][j][(i+1)*8-1 -: 8] = w_write_data256_packet_tmp[k][j].wdata[i];
-                    rdata_256_flat[k][j][(i+1)*8-1 -: 8] = w_read_data256_packet_tmp[k][j].rdata[i];     
+                    rdata_256_flat[k][j][(i+1)*8-1 -: 8] = w_read_data256_packet_tmp[k][j].rdata[i];
                 end
             end
-        
+
             for(int unsigned i = 0; i < 64; i = i + 1) begin
                 wdata_512_flat[k][(i+1)*8-1 -: 8]  = w_write_data512_packet_tmp[k].wdata[i];
                 rdata_512_flat[k][(i+1)*8-1 -: 8]  = w_read_data512_packet_tmp[k].rdata[i];
             end
-    
+
             for(int unsigned i = 0; i < 128; i = i + 1) begin
                 wdata_1024_flat[k][(i+1)*8-1 -: 8] = w_write_data1024_packet_tmp[k].wdata[i];
                 rdata_1024_flat[k][(i+1)*8-1 -: 8] = w_read_data1024_packet_tmp[k].rdata[i];
             end
-    
+
             for(int unsigned i = 0; i < 8; i = i + 1) begin
                 wstrb_512_flat[k][(i+1)*8-1 -: 8] = w_write_data512_packet_tmp[k].wstrb[i];
             end
-    
+
             for(int unsigned i = 0; i < 16; i = i + 1) begin
                 wstrb_1024_flat[k][(i+1)*8-1 -: 8] = w_write_data1024_packet_tmp[k].wstrb[i];
             end
         end
     end
-    
+
     integer idx_msg_sel_tmp, idx_dec_sel_tmp;
-    
+
     always_comb begin
         for(idx_dec_sel_tmp = 0; idx_dec_sel_tmp < DEC_MULTI; idx_dec_sel_tmp = idx_dec_sel_tmp + 1) begin
             for(idx_msg_sel_tmp = 0; idx_msg_sel_tmp < MAX_REQ_COUNT_CHUNK; idx_msg_sel_tmp = idx_msg_sel_tmp + 1) begin
@@ -973,7 +1030,7 @@ module AOU_RX_CORE
                 w_write_req_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].msg_type       = w_write_req_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].msg_type;
                 w_write_req_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rp             = w_write_req_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rp;
                 w_write_req_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rsvd           = 'd0;
-    
+
                 w_read_req_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].arid            = {w_read_req_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].arid_1, w_read_req_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].arid_0};
                 w_read_req_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].araddr          = araddr_flat[idx_dec_sel_tmp][idx_msg_sel_tmp];
                 w_read_req_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].arlen           = w_read_req_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].arlen;
@@ -988,7 +1045,7 @@ module AOU_RX_CORE
                 w_read_req_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rp              = w_read_req_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rp;
                 w_read_req_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rsvd            = 'd0;
             end
-            
+
             for(idx_msg_sel_tmp = 0; idx_msg_sel_tmp < MAX_DATA_COUNT_CHUNK; idx_msg_sel_tmp = idx_msg_sel_tmp + 1) begin
                 w_write_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].wdata      = wdata_256_flat[idx_dec_sel_tmp][idx_msg_sel_tmp];
                 w_write_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].wstrb      = wstrb_256_flat[idx_dec_sel_tmp][idx_msg_sel_tmp];
@@ -998,9 +1055,9 @@ module AOU_RX_CORE
                 w_write_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rp         = w_write_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rp;
                 w_write_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].dlength    = w_write_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].dlength;
                 w_write_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rsvd       = 'd0;
-    
+
                 w_read_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rdata       = rdata_256_flat[idx_dec_sel_tmp][idx_msg_sel_tmp];
-                w_read_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rid         = {w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rid_1, w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rid_0}; 
+                w_read_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rid         = {w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rid_1, w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rid_0};
                 w_read_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rresp       = w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rresp;
                 w_read_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rlast       = w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].rlast;
                 w_read_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].prof        = {w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].prof_1, w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].prof_0};
@@ -1010,7 +1067,7 @@ module AOU_RX_CORE
                 w_read_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].dlength     = w_read_data256_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].dlength;
                 w_read_data256_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].rsvd        = 'd0;
             end
-        
+
             w_write_data512_packet[idx_dec_sel_tmp].wdata                       = wdata_512_flat[idx_dec_sel_tmp];
             w_write_data512_packet[idx_dec_sel_tmp].wstrb                       = wstrb_512_flat[idx_dec_sel_tmp];
             w_write_data512_packet[idx_dec_sel_tmp].prof                        = {w_write_data512_packet_tmp[idx_dec_sel_tmp].prof_1, w_write_data512_packet_tmp[idx_dec_sel_tmp].prof_0};
@@ -1018,7 +1075,7 @@ module AOU_RX_CORE
             w_write_data512_packet[idx_dec_sel_tmp].msg_type                    = w_write_data512_packet_tmp[idx_dec_sel_tmp].msg_type;
             w_write_data512_packet[idx_dec_sel_tmp].rp                          = w_write_data512_packet_tmp[idx_dec_sel_tmp].rp;
             w_write_data512_packet[idx_dec_sel_tmp].dlength                     = w_write_data512_packet_tmp[idx_dec_sel_tmp].dlength;
-    
+
             w_write_data1024_packet[idx_dec_sel_tmp].wdata                      = wdata_1024_flat[idx_dec_sel_tmp];
             w_write_data1024_packet[idx_dec_sel_tmp].wstrb                      = wstrb_1024_flat[idx_dec_sel_tmp];
             w_write_data1024_packet[idx_dec_sel_tmp].prof                       = {w_write_data1024_packet_tmp[idx_dec_sel_tmp].prof_1, w_write_data1024_packet_tmp[idx_dec_sel_tmp].prof_0};
@@ -1027,7 +1084,7 @@ module AOU_RX_CORE
             w_write_data1024_packet[idx_dec_sel_tmp].rp                         = w_write_data1024_packet_tmp[idx_dec_sel_tmp].rp;
             w_write_data1024_packet[idx_dec_sel_tmp].dlength                    = w_write_data1024_packet_tmp[idx_dec_sel_tmp].dlength;
             w_write_data1024_packet[idx_dec_sel_tmp].rsvd                       = 'd0;
-    
+
             w_read_data512_packet[idx_dec_sel_tmp].rdata                        = rdata_512_flat[idx_dec_sel_tmp];
             w_read_data512_packet[idx_dec_sel_tmp].rid                          = {w_read_data512_packet_tmp[idx_dec_sel_tmp].rid_1, w_read_data512_packet_tmp[idx_dec_sel_tmp].rid_0} ;
             w_read_data512_packet[idx_dec_sel_tmp].rresp                        = w_read_data512_packet_tmp[idx_dec_sel_tmp].rresp;
@@ -1038,7 +1095,7 @@ module AOU_RX_CORE
             w_read_data512_packet[idx_dec_sel_tmp].rp                           = w_read_data512_packet_tmp[idx_dec_sel_tmp].rp;
             w_read_data512_packet[idx_dec_sel_tmp].dlength                      = w_read_data512_packet_tmp[idx_dec_sel_tmp].dlength;
             w_read_data512_packet[idx_dec_sel_tmp].rsvd                         = 'd0;
-            
+
             w_read_data1024_packet[idx_dec_sel_tmp].rdata                       = rdata_1024_flat[idx_dec_sel_tmp];
             w_read_data1024_packet[idx_dec_sel_tmp].rid                         = {w_read_data1024_packet_tmp[idx_dec_sel_tmp].rid_1, w_read_data1024_packet_tmp[idx_dec_sel_tmp].rid_0};
             w_read_data1024_packet[idx_dec_sel_tmp].rresp                       = w_read_data1024_packet_tmp[idx_dec_sel_tmp].rresp;
@@ -1049,7 +1106,7 @@ module AOU_RX_CORE
             w_read_data1024_packet[idx_dec_sel_tmp].rp                          = w_read_data1024_packet_tmp[idx_dec_sel_tmp].rp;
             w_read_data1024_packet[idx_dec_sel_tmp].dlength                     = w_read_data1024_packet_tmp[idx_dec_sel_tmp].dlength;
             w_read_data1024_packet[idx_dec_sel_tmp].rsvd                        = 'd0;
-    
+
             for(idx_msg_sel_tmp = 0; idx_msg_sel_tmp < MAX_WR_RESP_COUNT_CHUNK; idx_msg_sel_tmp = idx_msg_sel_tmp + 1) begin
                 w_write_resp_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].bid           = {w_write_resp_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].bid_1, w_write_resp_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].bid_0};
                 w_write_resp_packet[idx_dec_sel_tmp][idx_msg_sel_tmp].bresp         = w_write_resp_packet_tmp[idx_dec_sel_tmp][idx_msg_sel_tmp].bresp;
@@ -1061,10 +1118,10 @@ module AOU_RX_CORE
             end
         end
     end
-    
-//------------------------------------------------------------- 
+
+//-------------------------------------------------------------
     genvar x,y,z;
-    generate 
+    generate
         for (z = 0; z < RP_COUNT; z = z + 1) begin
             for(y = 0; y < DEC_MULTI; y = y + 1) begin
 
@@ -1077,35 +1134,35 @@ module AOU_RX_CORE
                                                                                                  w_write_req_packet[y][x].awcache    ,
                                                                                                  w_write_req_packet[y][x].awprot     ,
                                                                                                  w_write_req_packet[y][x].awqos      } : {(AW_AR_FIFO_DATA_WIDTH){1'b0}};
-                    assign O_WR_REQ_FIFO_SVALID[z][y][x] = (z == w_write_req_packet[y][x].rp) ? (|wait_valid_chunk) ? (w_write_req_valid[y][x] && w_rx_chunk_data_valid) : w_write_req_valid[y][x] : 1'b0;  
-                end 
-    
+                    assign O_WR_REQ_FIFO_SVALID[z][y][x] = (z == w_write_req_packet[y][x].rp) ? (|wait_valid_chunk) ? (w_write_req_valid[y][x] && w_rx_chunk_data_valid) : w_write_req_valid[y][x] : 1'b0;
+                end
+
                 assign O_WR_DATA_FIFO_SDATA[z][y][0] = (z == w_write_data1024_packet[y].rp) ? w_write_data1024_packet[y].wdata : {(AXI_PEER_DIE_MAX_DATA_WD){1'b0}};
                 assign O_WR_DATA_FIFO_SDATA[z][y][1] = (z == w_write_data512_packet[y].rp) ? {{(AXI_PEER_DIE_MAX_DATA_WD-512){1'b0}}, w_write_data512_packet[y].wdata[511:0]} : {(AXI_PEER_DIE_MAX_DATA_WD){1'b0}};
                 assign O_WR_DATA_FIFO_SDATA[z][y][2] = (z == w_write_data256_packet[y][0].rp) ? {{(AXI_PEER_DIE_MAX_DATA_WD-256){1'b0}}, w_write_data256_packet[y][0].wdata[255:0]} : {(AXI_PEER_DIE_MAX_DATA_WD){1'b0}};
                 assign O_WR_DATA_FIFO_SDATA[z][y][3] = (z == w_write_data256_packet[y][1].rp) ? {{(AXI_PEER_DIE_MAX_DATA_WD-256){1'b0}}, w_write_data256_packet[y][1].wdata[255:0]} : {(AXI_PEER_DIE_MAX_DATA_WD){1'b0}};
-    
-                assign O_WR_DATA_FIFO_SDATA_STRB[z][y][0] = (z == w_write_data1024_packet[y].rp) ? (w_write_data1024_packet[y].msg_type == MSG_WR_DATA) ? w_write_data1024_packet[y].wstrb : 128'hffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff : {AXI_STRB_WD{1'b0}};  
-                assign O_WR_DATA_FIFO_SDATA_STRB[z][y][1] = (z == w_write_data512_packet[y].rp) ? (w_write_data512_packet[y].msg_type == MSG_WR_DATA) ? w_write_data512_packet[y].wstrb : {{(AXI_STRB_WD-64){1'b0}}, 64'hffff_ffff_ffff_ffff} : {AXI_STRB_WD{1'b0}};  
-                assign O_WR_DATA_FIFO_SDATA_STRB[z][y][2] = (z == w_write_data256_packet[y][0].rp) ? (w_write_data256_packet[y][0].msg_type == MSG_WR_DATA) ? w_write_data256_packet[y][0].wstrb : {{(AXI_STRB_WD-32){1'b0}}, 32'hffff_ffff} : {AXI_STRB_WD{1'b0}};  
-                assign O_WR_DATA_FIFO_SDATA_STRB[z][y][3] = (z == w_write_data256_packet[y][1].rp) ? (w_write_data256_packet[y][1].msg_type == MSG_WR_DATA) ? w_write_data256_packet[y][1].wstrb : {{(AXI_STRB_WD-32){1'b0}}, 32'hffff_ffff} : {AXI_STRB_WD{1'b0}};  
+
+                assign O_WR_DATA_FIFO_SDATA_STRB[z][y][0] = (z == w_write_data1024_packet[y].rp) ? (w_write_data1024_packet[y].msg_type == MSG_WR_DATA) ? w_write_data1024_packet[y].wstrb : 128'hffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff : {AXI_STRB_WD{1'b0}};
+                assign O_WR_DATA_FIFO_SDATA_STRB[z][y][1] = (z == w_write_data512_packet[y].rp) ? (w_write_data512_packet[y].msg_type == MSG_WR_DATA) ? w_write_data512_packet[y].wstrb : {{(AXI_STRB_WD-64){1'b0}}, 64'hffff_ffff_ffff_ffff} : {AXI_STRB_WD{1'b0}};
+                assign O_WR_DATA_FIFO_SDATA_STRB[z][y][2] = (z == w_write_data256_packet[y][0].rp) ? (w_write_data256_packet[y][0].msg_type == MSG_WR_DATA) ? w_write_data256_packet[y][0].wstrb : {{(AXI_STRB_WD-32){1'b0}}, 32'hffff_ffff} : {AXI_STRB_WD{1'b0}};
+                assign O_WR_DATA_FIFO_SDATA_STRB[z][y][3] = (z == w_write_data256_packet[y][1].rp) ? (w_write_data256_packet[y][1].msg_type == MSG_WR_DATA) ? w_write_data256_packet[y][1].wstrb : {{(AXI_STRB_WD-32){1'b0}}, 32'hffff_ffff} : {AXI_STRB_WD{1'b0}};
 
                 assign O_WR_DATA_FIFO_SDATA_WDATAF[z][y][0] = (z == w_write_data1024_packet[y].rp) ? (w_write_data1024_packet[y].msg_type == MSG_WR_DATA) ? 1'b0 : 1'b1 : 1'b0;
                 assign O_WR_DATA_FIFO_SDATA_WDATAF[z][y][1] = (z == w_write_data512_packet[y].rp) ? (w_write_data512_packet[y].msg_type == MSG_WR_DATA) ? 1'b0 : 1'b1 : 1'b0;
                 assign O_WR_DATA_FIFO_SDATA_WDATAF[z][y][2] = (z == w_write_data256_packet[y][0].rp) ? (w_write_data256_packet[y][0].msg_type == MSG_WR_DATA) ? 1'b0 : 1'b1 : 1'b0;
                 assign O_WR_DATA_FIFO_SDATA_WDATAF[z][y][3] = (z == w_write_data256_packet[y][1].rp) ? (w_write_data256_packet[y][1].msg_type == MSG_WR_DATA) ? 1'b0 : 1'b1 : 1'b0;
-       
+
                 assign O_WR_DATA_FIFO_SVALID[z][y][0] = (z == w_write_data1024_packet[y].rp) ? (w_write_data1024_packet[y].dlength == 2'b10) ? (|wait_valid_chunk) ? (w_write_data_valid[y][w_valid_write_data_cnt[y][MAX_DATA_WD-1:0]] && w_rx_chunk_data_valid) : w_write_data_valid[y][w_valid_write_data_cnt[y][MAX_DATA_WD-1:0]] : 1'b0 : 1'b0;
                 assign O_WR_DATA_FIFO_SVALID[z][y][1] = (z == w_write_data512_packet[y].rp) ? (w_write_data512_packet[y].dlength == 2'b01) ? (|wait_valid_chunk) ? (w_write_data_valid[y+1][w_valid_write_data_cnt[y+1][MAX_DATA_WD-1:0]] && w_rx_chunk_data_valid) : w_write_data_valid[y+1][w_valid_write_data_cnt[y+1][MAX_DATA_WD-1:0]] : 1'b0 : 1'b0;
                 assign O_WR_DATA_FIFO_SVALID[z][y][2] = (z == w_write_data256_packet[y][0].rp) ? (w_write_data256_packet[y][0].dlength == 2'b00) ? (|wait_valid_chunk) ? (w_write_data_valid[y+2][0] && w_rx_chunk_data_valid) : (w_write_data_valid[y+2][0] && !r_write_data_mask) : 1'b0 : 1'b0;
                 assign O_WR_DATA_FIFO_SVALID[z][y][3] = (z == w_write_data256_packet[y][1].rp) ? (w_write_data256_packet[y][1].dlength == 2'b00) ? (|wait_valid_chunk) ? (w_write_data_valid[y+2][1] && w_rx_chunk_data_valid) : w_write_data_valid[y+2][1] : 1'b0 : 1'b0;
-    
+
 
                 for (x = 0; x < MAX_WR_RESP_COUNT_CHUNK; x = x + 1) begin
                     assign O_WR_RESP_FIFO_SDATA[z][y][x] = (z == w_write_resp_packet[y][x].rp) ? { w_write_resp_packet[y][x].bid       ,
                                                                                                    w_write_resp_packet[y][x].bresp      } : {(B_FIFO_DATA_WIDTH){1'b0}};
                     assign O_WR_RESP_FIFO_SVALID[z][y][x] = (z == w_write_resp_packet[y][x].rp) ? (i_write_resp_valid[y][x] && w_rx_chunk_data_valid) : 1'b0;
-                end 
+                end
 
                 for (x = 0; x < MAX_REQ_COUNT_CHUNK; x = x + 1) begin
                     assign O_RD_REQ_FIFO_SDATA[z][y][x] = (z == w_read_req_packet[y][x].rp) ? { w_read_req_packet[y][x].arid       ,
@@ -1117,29 +1174,29 @@ module AOU_RX_CORE
                                                                                                 w_read_req_packet[y][x].arprot     ,
                                                                                                 w_read_req_packet[y][x].arqos      } : {(AW_AR_FIFO_DATA_WIDTH){1'b0}};
                     assign O_RD_REQ_FIFO_SVALID[z][y][x] = (z == w_read_req_packet[y][x].rp) ? (|wait_valid_chunk) ? (w_read_req_valid[y][x] && w_rx_chunk_data_valid) : w_read_req_valid[y][x] : 1'b0;
-                end 
+                end
 
                 assign O_RD_DATA_FIFO_SDATA[z][y][0] = (z == w_read_data1024_packet[y].rp) ? w_read_data1024_packet[y].rdata[1023:0] : {(AXI_PEER_DIE_MAX_DATA_WD){1'b0}};
                 assign O_RD_DATA_FIFO_SDATA[z][y][1] = (z == w_read_data512_packet[y].rp) ? {{(AXI_PEER_DIE_MAX_DATA_WD-512){1'b0}}, w_read_data512_packet[y].rdata[511:0]} : {(AXI_PEER_DIE_MAX_DATA_WD){1'b0}};
                 assign O_RD_DATA_FIFO_SDATA[z][y][2] = (z == w_read_data256_packet[y][0].rp) ? {{(AXI_PEER_DIE_MAX_DATA_WD-256){1'b0}}, w_read_data256_packet[y][0].rdata[255:0]} : {(AXI_PEER_DIE_MAX_DATA_WD){1'b0}};
                 assign O_RD_DATA_FIFO_SDATA[z][y][3] = (z == w_read_data256_packet[y][1].rp) ? {{(AXI_PEER_DIE_MAX_DATA_WD-256){1'b0}}, w_read_data256_packet[y][1].rdata[255:0]} : {(AXI_PEER_DIE_MAX_DATA_WD){1'b0}};
-    
+
                 assign O_RD_DATA_FIFO_EXT_SDATA[z][y][0] = (z == w_read_data1024_packet[y].rp) ? {w_read_data1024_packet[y].rid     ,
                                                                                                   w_read_data1024_packet[y].rresp   ,
                                                                                                   w_read_data1024_packet[y].rlast} : {R_FIFO_EXT_DATA_WIDTH{1'b0}};
-    
+
                 assign O_RD_DATA_FIFO_EXT_SDATA[z][y][1] = (z == w_read_data512_packet[y].rp) ? {w_read_data512_packet[y].rid     ,
                                                                                                  w_read_data512_packet[y].rresp   ,
                                                                                                  w_read_data512_packet[y].rlast} : {R_FIFO_EXT_DATA_WIDTH{1'b0}};
-    
+
                 assign O_RD_DATA_FIFO_EXT_SDATA[z][y][2] = (z == w_read_data256_packet[y][0].rp) ? {w_read_data256_packet[y][0].rid     ,
                                                                                                     w_read_data256_packet[y][0].rresp   ,
                                                                                                     w_read_data256_packet[y][0].rlast} : {R_FIFO_EXT_DATA_WIDTH{1'b0}};
-    
+
                 assign O_RD_DATA_FIFO_EXT_SDATA[z][y][3] = (z == w_read_data256_packet[y][1].rp) ? {w_read_data256_packet[y][1].rid     ,
                                                                                                     w_read_data256_packet[y][1].rresp   ,
                                                                                                     w_read_data256_packet[y][1].rlast} : {R_FIFO_EXT_DATA_WIDTH{1'b0}};
-                                   
+
                 assign O_RD_DATA_FIFO_SVALID[z][y][0] = (z == w_read_data1024_packet[y].rp) ? (w_read_data1024_packet[y].dlength == 2'b10) ? (|wait_valid_chunk) ? (w_read_data_valid[y][w_valid_read_data_cnt[y][MAX_DATA_WD-1:0]] && w_rx_chunk_data_valid) : w_read_data_valid[y][w_valid_read_data_cnt[y][MAX_DATA_WD-1:0]] : 1'b0 : 1'b0;
                 assign O_RD_DATA_FIFO_SVALID[z][y][1] = (z == w_read_data512_packet[y].rp) ? (w_read_data512_packet[y].dlength == 2'b01) ? (|wait_valid_chunk) ? (w_read_data_valid[y+1][w_valid_read_data_cnt[y+1][MAX_DATA_WD-1:0]] && w_rx_chunk_data_valid) : w_read_data_valid[y+1][w_valid_read_data_cnt[y+1][MAX_DATA_WD-1:0]] : 1'b0 : 1'b0;
                 assign O_RD_DATA_FIFO_SVALID[z][y][2] = (z == w_read_data256_packet[y][0].rp) ? (w_read_data256_packet[y][0].dlength == 2'b00) ? (|wait_valid_chunk) ? (w_read_data_valid[y+2][0] && w_rx_chunk_data_valid) : (w_read_data_valid[y+2][0] && !r_read_data_mask): 1'b0 : 1'b0;
@@ -1148,7 +1205,7 @@ module AOU_RX_CORE
             end
         end
     endgenerate
-    
+
     //-------------------------------------------------------------
     generate
         for(y = 0; y < DEC_MULTI; y = y + 1) begin
@@ -1177,7 +1234,7 @@ module AOU_RX_CORE
             end
         end
     endgenerate
-    
+
     assign O_MSGCRDT_WRESPCRED     = i_msg_credit.wrespcred;
     assign O_MSGCRDT_RDATACRED     = i_msg_credit.rdatacred;
     assign O_MSGCRDT_WDATACRED     = i_msg_credit.wdatacred;
@@ -1185,7 +1242,7 @@ module AOU_RX_CORE
     assign O_MSGCRDT_WREQCRED      = i_msg_credit.wreqcred;
     assign O_MSGCRDT_RP            = i_msg_credit.rp;
     assign O_MSGCRDT_VALID         = (PHY_TYPE < 2) ? ((r_aou_rx_phase == 2'b10) && w_rx_chunk_data_valid) : (PHY_TYPE == 2) ? ((r_aou_rx_phase[0] == 1'b1) && w_rx_chunk_data_valid) : w_rx_chunk_data_valid;
-    
+
     assign O_ACTIVATION_OP         = {w_misc_activation_packet.activation_op_1, w_misc_activation_packet.activation_op_0};
     assign O_ACTIVATION_PROP_REQ   = w_misc_activation_packet.property_req;
     assign O_ACTIVATION_VALID      = (w_misc_activation_packet.misc_op == 3'b010) ? (i_misc_valid[0][0] && w_rx_chunk_data_valid) : 1'b0;

--- a/RTL/AOU_SYNC_FIFO_NS1M.sv
+++ b/RTL/AOU_SYNC_FIFO_NS1M.sv
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -44,7 +45,7 @@ module AOU_SYNC_FIFO_NS1M
     input    [ICH_CNT -1:0]                 I_SVALID,
     input    [ICH_CNT -1:0][FIFO_WIDTH-1:0] I_SDATA,
     output                                  O_SREADY,
-    
+
     input                                   I_MREADY,
     output   [FIFO_WIDTH-1:0]               O_MDATA,
     output                                  O_MVALID,
@@ -74,14 +75,20 @@ always_comb begin
 
     for (idx_write_req = 0; idx_write_req < ICH_CNT; idx_write_req = idx_write_req + 1) begin
         if (I_SVALID[idx_write_req] == 1'b1) begin
-            w_nxt_fifo_data[w_write_req_cnt[ICH_WD-1:0]] = I_SDATA[idx_write_req]; 
+            w_nxt_fifo_data[w_write_req_cnt[ICH_WD-1:0]] = I_SDATA[idx_write_req];
             w_nxt_wr_ptr[w_write_req_cnt[ICH_WD-1:0]] = (r_wr_ptr + w_write_req_cnt >= FIFO_DEPTH) ? (r_wr_ptr + w_write_req_cnt - FIFO_DEPTH) : (r_wr_ptr + w_write_req_cnt);
             w_write_req_cnt = w_write_req_cnt + 1;
         end
     end
 end
 
-//for write 
+//for write
+//
+// The write port is expressed as a per-entry mux/enable network so that the
+// indexed select r_fifo[w_nxt_wr_ptr[i]] never appears with an out-of-range
+// address when FIFO_DEPTH is not a power of two. This avoids X don't-care
+// injection that would otherwise expand into a large set of LEC "E" key
+// points (with the associated runtime / abort cost).
 integer i;
 always_ff @ (posedge I_CLK or negedge I_RESETN) begin
     if (~I_RESETN) begin
@@ -92,12 +99,17 @@ always_ff @ (posedge I_CLK or negedge I_RESETN) begin
         r_ex_wr_ptr <= 0;
     end else begin
         if (|I_SVALID & O_SREADY ) begin
-            for (i = 0; i < ICH_CNT; i = i+1) begin
-                if(i < w_write_req_cnt) r_fifo[w_nxt_wr_ptr[i][AW-1:0]] <= w_nxt_fifo_data[i];
+            for (int j = 0; j < FIFO_DEPTH; j = j+1) begin
+                for (int wi = 0; wi < ICH_CNT; wi = wi+1) begin
+                    if ((wi < w_write_req_cnt) &&
+                        (w_nxt_wr_ptr[wi][AW-1:0] == j[AW-1:0])) begin
+                        r_fifo[j] <= w_nxt_fifo_data[wi];
+                    end
+                end
             end
             r_wr_ptr <= (r_wr_ptr + w_write_req_cnt >= FIFO_DEPTH) ? (r_wr_ptr + w_write_req_cnt - FIFO_DEPTH) : (r_wr_ptr + w_write_req_cnt);
             r_ex_wr_ptr <= (r_wr_ptr + w_write_req_cnt >= FIFO_DEPTH) ?  ~r_ex_wr_ptr : r_ex_wr_ptr;
-        end 
+        end
     end
 end
 
@@ -133,8 +145,21 @@ assign O_M_DATA_CNT = r_data_cnt;
 
 assign O_SREADY = (ALWAYS_READY == 1) ? 1'b1 : (O_S_EMPTY_CNT >= ICH_CNT) ;
 
-assign O_MVALID = ~((r_wr_ptr == r_rd_ptr) & (r_ex_wr_ptr == r_ex_rd_ptr)); 
-assign O_MDATA = r_fifo[r_rd_ptr];
+assign O_MVALID = ~((r_wr_ptr == r_rd_ptr) & (r_ex_wr_ptr == r_ex_rd_ptr));
+
+// Read mux is built as an explicit one-hot select over the reachable index
+// range [0, FIFO_DEPTH-1] so that pointer values in the unreachable range
+// [FIFO_DEPTH, 2**AW-1] -- which the wrap arithmetic above guarantees never
+// occur -- do not introduce out-of-range X don't-cares. Same motivation as
+// the write port above: keeps LEC clean of redundant "E" key points.
+logic [FIFO_WIDTH-1:0] w_rd_data;
+always_comb begin
+    w_rd_data = '0;
+    for (int j = 0; j < FIFO_DEPTH; j = j+1) begin
+        if (r_rd_ptr == j[AW-1:0]) w_rd_data = r_fifo[j];
+    end
+end
+assign O_MDATA = w_rd_data;
 
 endmodule
 

--- a/RTL/AOU_SYNC_FIFO_REG.v
+++ b/RTL/AOU_SYNC_FIFO_REG.v
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -45,7 +46,7 @@ module AOU_SYNC_FIFO_REG #(
     output                      O_MVALID        ,
 
     output  [CNT_WD-1: 0]       O_EMPTY_CNT     ,
-    output  [CNT_WD-1: 0]       O_FULL_CNT      
+    output  [CNT_WD-1: 0]       O_FULL_CNT
 );
 //-------------------------------------------------------------------
     reg  [CNT_WD-1: 0]          r_empty_cnt     ;
@@ -64,12 +65,20 @@ module AOU_SYNC_FIFO_REG #(
     reg  [FIFO_WIDTH-1 : 0]     mem [FIFO_DEPTH-1 : 0]  ;
 //-------------------------------------------------------------------
     assign nxt_r_cnt = (r_cnt == FIFO_DEPTH-1) ? ({AW{1'b0}}) : (r_cnt + 1'b1);
-    assign nxt_w_cnt = (w_cnt == FIFO_DEPTH-1) ? ({AW{1'b0}}) : (w_cnt + 1'b1);     
+    assign nxt_w_cnt = (w_cnt == FIFO_DEPTH-1) ? ({AW{1'b0}}) : (w_cnt + 1'b1);
 
     assign nxt_r_ex_cnt = (r_cnt == FIFO_DEPTH-1) ? ~r_ex_cnt : r_ex_cnt;
-    assign nxt_w_ex_cnt = (w_cnt == FIFO_DEPTH-1) ? ~w_ex_cnt : w_ex_cnt;     
+    assign nxt_w_ex_cnt = (w_cnt == FIFO_DEPTH-1) ? ~w_ex_cnt : w_ex_cnt;
 //-------------------------------------------------------------------
+    // The mem write port is expressed as a per-entry decode (for-loop with
+    // explicit address compare per entry) so the indexed select mem[w_cnt]
+    // never appears with an out-of-range address when FIFO_DEPTH is not a
+    // power of two. This avoids the X don't-care lanes that would otherwise
+    // expand into a large set of LEC "E" key points (with the associated
+    // runtime / abort cost). Synthesis result is unchanged: the same one-hot
+    // decode + per-entry enable network is produced either way.
     integer i;
+    integer wr_k;
     always @(posedge I_CLK or negedge I_RESETN) begin
         if (!I_RESETN) begin
             w_cnt <= {AW{1'b0}};
@@ -77,7 +86,7 @@ module AOU_SYNC_FIFO_REG #(
 
             r_cnt <= {AW{1'b0}};
             r_ex_cnt <= 1'b0;
-            
+
             for(i = 0; i < FIFO_DEPTH; i = i + 1)
                 mem[i] <= 0;
 
@@ -86,7 +95,9 @@ module AOU_SYNC_FIFO_REG #(
             if ( I_SVALID && O_SREADY) begin
                 w_cnt       <= nxt_w_cnt;
                 w_ex_cnt    <= nxt_w_ex_cnt;
-                mem[w_cnt]  <= I_SDATA;
+                for (wr_k = 0; wr_k < FIFO_DEPTH; wr_k = wr_k + 1) begin
+                    if (w_cnt == wr_k[AW-1:0]) mem[wr_k] <= I_SDATA;
+                end
             end
 
             // read transaction here
@@ -95,7 +106,7 @@ module AOU_SYNC_FIFO_REG #(
                 r_ex_cnt    <= nxt_r_ex_cnt;
             end
         end
-    end   
+    end
 
 //-------------------------------------------------------------------
     always @(posedge I_CLK or negedge I_RESETN) begin
@@ -110,7 +121,7 @@ module AOU_SYNC_FIFO_REG #(
                 r_empty_cnt <= r_empty_cnt + 1;
             end
         end
-    end   
+    end
 
     assign O_EMPTY_CNT = r_empty_cnt;
 
@@ -126,13 +137,28 @@ module AOU_SYNC_FIFO_REG #(
                 r_full_cnt <= r_full_cnt - 1;
             end
         end
-    end   
+    end
 
     assign O_FULL_CNT = r_full_cnt;
 //-------------------------------------------------------------------
     assign O_SREADY  =   ~((w_cnt == r_cnt) & (r_ex_cnt != w_ex_cnt)) ;
     assign O_MVALID  =   ~((w_cnt == r_cnt) & (r_ex_cnt == w_ex_cnt));
-    assign O_MDATA   =   mem[r_cnt];
+
+    // Read mux for mem. Built as an explicit one-hot select over the
+    // reachable index range [0, FIFO_DEPTH-1] so r_cnt values in the
+    // unreachable range [FIFO_DEPTH, 2**AW-1] -- which the wrap arithmetic
+    // above guarantees never occur -- do not introduce out-of-range X
+    // don't-cares. Same motivation as the write port above: keeps LEC clean
+    // of redundant "E" key points.
+    reg  [FIFO_WIDTH-1 : 0] r_mdata;
+    integer rd_k;
+    always @* begin
+        r_mdata = {FIFO_WIDTH{1'b0}};
+        for (rd_k = 0; rd_k < FIFO_DEPTH; rd_k = rd_k + 1) begin
+            if (r_cnt == rd_k[AW-1:0]) r_mdata = mem[rd_k];
+        end
+    end
+    assign O_MDATA   =   r_mdata;
 
 //-------------------------------------------------------------------
 `ifdef ASSERTION_ON
@@ -141,7 +167,7 @@ module AOU_SYNC_FIFO_REG #(
 ready_valid_assertion:
     assert
         property (
-            @(posedge I_CLK) (I_SVALID) |-> 
+            @(posedge I_CLK) (I_SVALID) |->
                 (CONSTRAINT_SREADY_ALWAYS_1 ?  O_SREADY : 1'b1)
         )
         else begin

--- a/RTL/AOU_TOP.sv
+++ b/RTL/AOU_TOP.sv
@@ -1,6 +1,7 @@
 // *****************************************************************************
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
+//  Copyright (c) 2026 BOS Semiconductors
 //  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/RTL/AOU_TOP.sv
+++ b/RTL/AOU_TOP.sv
@@ -1,7 +1,7 @@
 // *****************************************************************************
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
-//  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -24,6 +24,14 @@
 //               into the AOU core, replacing the former external UCIE_CORE
 //               connection.
 //
+//               FDI data-plane ports mirror AOU_CORE_TOP's _0/_1 naming and
+//               `+define+TWO_PHY gating: PHY0 is always present, PHY1 and
+//               I_PHY_TYPE are exposed only when built with `+define+TWO_PHY.
+//               The single FDI_CONFIG parameter selects the FDI width pair
+//               for both PHYs and is forwarded directly to AOU_CORE_TOP.
+//               Local FDI_IF_WD0 / FDI_IF_WD1 localparams are derived from
+//               FDI_CONFIG only for sizing this wrapper's own FDI ports.
+//
 // *****************************************************************************
 
 `timescale 1ns/1ps
@@ -31,31 +39,62 @@
 module AOU_TOP
 import packet_def_pkg::*;
 #(
-    parameter   RP_COUNT                    = 2,
+    parameter   RP_COUNT                    = 1,
 
+    // FDI configuration selector. Single integer that picks the FDI data
+    // bus widths for both PHYs and (in two-PHY builds) the per-PHY pairing.
+    // See packet_def_pkg::FDI_CFG_* for the enumeration. Forwarded
+    // unchanged to u_aou_core_top below; the local FDI_IF_WD0 / FDI_IF_WD1
+    // localparams are derived from FDI_CONFIG only to size this wrapper's
+    // own FDI ports and the FIFO-depth defaults. Default matches the
+    // legacy +define+FDI_32B single-PHY configuration. Consistency between
+    // FDI_CONFIG and +define+TWO_PHY is the integrator's responsibility.
+    parameter int FDI_CONFIG                = FDI_CFG_SP_32B,
+
+    // Derived FDI data bus widths (bits). Local-only; not forwarded.
+    localparam int FDI_IF_WD0 = (FDI_CONFIG == FDI_CFG_SP_32B     ) ? 256  :
+                                (FDI_CONFIG == FDI_CFG_SP_64B     ) ? 512  :
+                                (FDI_CONFIG == FDI_CFG_SP_128B    ) ? 1024 :
+                                (FDI_CONFIG == FDI_CFG_TP_32B_64B ) ? 256  :
+                                (FDI_CONFIG == FDI_CFG_TP_64B_128B) ? 512  : 256,
+    localparam int FDI_IF_WD1 = (FDI_CONFIG == FDI_CFG_SP_32B     ) ? 512  :
+                                (FDI_CONFIG == FDI_CFG_SP_64B     ) ? 512  :
+                                (FDI_CONFIG == FDI_CFG_SP_128B    ) ? 1024 :
+                                (FDI_CONFIG == FDI_CFG_TP_32B_64B ) ? 512  :
+                                (FDI_CONFIG == FDI_CFG_TP_64B_128B) ? 1024 : 512,
+
+    // FIFO depths default to 140 for 1024b (128B) FDI data paths, 88 otherwise.
+    // Matches the original +define+FDI_128B branch which applied to both
+    // single-PHY (FDI_IF_WD0 == 1024) and two-PHY (FDI_IF_WD1 == 1024) cases.
     parameter   RP0_RX_AW_FIFO_DEPTH        = 44,
     parameter   RP0_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP0_RX_W_FIFO_DEPTH         = 88,
-    parameter   RP0_RX_R_FIFO_DEPTH         = 88,
+    parameter   RP0_RX_W_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
+    parameter   RP0_RX_R_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
     parameter   RP0_RX_B_FIFO_DEPTH         = 44,
 
     parameter   RP1_RX_AW_FIFO_DEPTH        = 44,
     parameter   RP1_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP1_RX_W_FIFO_DEPTH         = 88,
-    parameter   RP1_RX_R_FIFO_DEPTH         = 88,
+    parameter   RP1_RX_W_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
+    parameter   RP1_RX_R_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
     parameter   RP1_RX_B_FIFO_DEPTH         = 44,
 
     parameter   RP2_RX_AW_FIFO_DEPTH        = 44,
     parameter   RP2_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP2_RX_W_FIFO_DEPTH         = 88,
-    parameter   RP2_RX_R_FIFO_DEPTH         = 88,
+    parameter   RP2_RX_W_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
+    parameter   RP2_RX_R_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
     parameter   RP2_RX_B_FIFO_DEPTH         = 44,
 
     parameter   RP3_RX_AW_FIFO_DEPTH        = 44,
     parameter   RP3_RX_AR_FIFO_DEPTH        = 44,
-    parameter   RP3_RX_W_FIFO_DEPTH         = 88,
-    parameter   RP3_RX_R_FIFO_DEPTH         = 88,
+    parameter   RP3_RX_W_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
+    parameter   RP3_RX_R_FIFO_DEPTH         = ((FDI_IF_WD0 == 1024) || (FDI_IF_WD1 == 1024)) ? 140 : 88,
     parameter   RP3_RX_B_FIFO_DEPTH         = 44,
+
+    parameter   RX_AW_FIFO_RS_EN            = 1,
+    parameter   RX_AR_FIFO_RS_EN            = 1,
+    parameter   RX_W_FIFO_RS_EN             = 1,
+    parameter   RX_R_FIFO_RS_EN             = 1,
+    parameter   RX_B_FIFO_RS_EN             = 1,
 
     parameter   RP0_AXI_DATA_WD             = 512,
     parameter   RP1_AXI_DATA_WD             = 512,
@@ -191,36 +230,43 @@ import packet_def_pkg::*;
     input  logic [RP_COUNT-1:0]                         I_AOU_RX_AXI_S_BREADY,
 
     // ================================================================
-    // PHY type select
+    // PHY type select (TWO_PHY only)
     // ================================================================
+`ifdef TWO_PHY
     input  logic                                        I_PHY_TYPE,
+`endif
 
     // ================================================================
-    // FDI data-path interface (directly to AOU_CORE_TOP)
+    // FDI data-path interface - PHY0 (always present)
     // ================================================================
-    input  logic                                        I_FDI_PL_32B_VALID,
-    input  logic [32*8-1:0]                             I_FDI_PL_32B_DATA,
-    input  logic                                        I_FDI_PL_32B_FLIT_CANCEL,
+    input  logic                                        I_FDI_PL_0_VALID,
+    input  logic [FDI_IF_WD0-1:0]                       I_FDI_PL_0_DATA,
+    input  logic                                        I_FDI_PL_0_FLIT_CANCEL,
 
-    input  logic                                        I_FDI_PL_64B_VALID,
-    input  logic [64*8-1:0]                             I_FDI_PL_64B_DATA,
-    input  logic                                        I_FDI_PL_64B_FLIT_CANCEL,
+    input  logic                                        I_FDI_PL_0_TRDY,
+    input  logic                                        I_FDI_PL_0_STALLREQ,
+    input  logic [3:0]                                  I_FDI_PL_0_STATE_STS,
+    output logic [FDI_IF_WD0-1:0]                       O_FDI_LP_0_DATA,
+    output logic                                        O_FDI_LP_0_VALID,
+    output logic                                        O_FDI_LP_0_IRDY,
+    output logic                                        O_FDI_LP_0_STALLACK,
 
-    input  logic                                        I_FDI_PL_32B_TRDY,
-    input  logic                                        I_FDI_PL_32B_STALLREQ,
-    input  logic [3:0]                                  I_FDI_PL_32B_STATE_STS,
-    output logic [255:0]                                O_FDI_LP_32B_DATA,
-    output logic                                        O_FDI_LP_32B_VALID,
-    output logic                                        O_FDI_LP_32B_IRDY,
-    output logic                                        O_FDI_LP_32B_STALLACK,
+    // ================================================================
+    // FDI data-path interface - PHY1 (TWO_PHY only)
+    // ================================================================
+`ifdef TWO_PHY
+    input  logic                                        I_FDI_PL_1_VALID,
+    input  logic [FDI_IF_WD1-1:0]                       I_FDI_PL_1_DATA,
+    input  logic                                        I_FDI_PL_1_FLIT_CANCEL,
 
-    input  logic                                        I_FDI_PL_64B_TRDY,
-    input  logic                                        I_FDI_PL_64B_STALLREQ,
-    input  logic [3:0]                                  I_FDI_PL_64B_STATE_STS,
-    output logic [511:0]                                O_FDI_LP_64B_DATA,
-    output logic                                        O_FDI_LP_64B_VALID,
-    output logic                                        O_FDI_LP_64B_IRDY,
-    output logic                                        O_FDI_LP_64B_STALLACK,
+    input  logic                                        I_FDI_PL_1_TRDY,
+    input  logic                                        I_FDI_PL_1_STALLREQ,
+    input  logic [3:0]                                  I_FDI_PL_1_STATE_STS,
+    output logic [FDI_IF_WD1-1:0]                       O_FDI_LP_1_DATA,
+    output logic                                        O_FDI_LP_1_VALID,
+    output logic                                        O_FDI_LP_1_IRDY,
+    output logic                                        O_FDI_LP_1_STALLACK,
+`endif
 
     // ================================================================
     // FDI bringup control interface (to AOU_FDI_BRINGUP_CTRL)
@@ -281,15 +327,23 @@ import packet_def_pkg::*;
     logic        w_int_activate_start;
     logic        w_int_deactivate_start;
 
-    // Mux pl_state_sts based on active PHY width
+    // Mux pl_state_sts / stallreq based on active PHY. Under TWO_PHY both PHYs
+    // are valid and I_PHY_TYPE selects which one drives the bringup
+    // controller; in single-PHY builds only PHY0 is present so its signals
+    // are wired through directly.
     logic [3:0]  w_pl_state_sts_muxed;
     logic        w_pl_stallreq_muxed;
 
-    assign w_pl_state_sts_muxed = I_PHY_TYPE ? I_FDI_PL_64B_STATE_STS
-                                             : I_FDI_PL_32B_STATE_STS;
+`ifdef TWO_PHY
+    assign w_pl_state_sts_muxed = I_PHY_TYPE ? I_FDI_PL_1_STATE_STS
+                                             : I_FDI_PL_0_STATE_STS;
 
-    assign w_pl_stallreq_muxed  = I_PHY_TYPE ? I_FDI_PL_64B_STALLREQ
-                                             : I_FDI_PL_32B_STALLREQ;
+    assign w_pl_stallreq_muxed  = I_PHY_TYPE ? I_FDI_PL_1_STALLREQ
+                                             : I_FDI_PL_0_STALLREQ;
+`else
+    assign w_pl_state_sts_muxed = I_FDI_PL_0_STATE_STS;
+    assign w_pl_stallreq_muxed  = I_FDI_PL_0_STALLREQ;
+`endif
 
     // ================================================================
     // FDI Bringup Controller
@@ -332,6 +386,8 @@ import packet_def_pkg::*;
     AOU_CORE_TOP #(
         .RP_COUNT                   ( RP_COUNT                      ),
 
+        .FDI_CONFIG                ( FDI_CONFIG                   ),
+
         .RP0_RX_AW_FIFO_DEPTH      ( RP0_RX_AW_FIFO_DEPTH         ),
         .RP0_RX_AR_FIFO_DEPTH      ( RP0_RX_AR_FIFO_DEPTH         ),
         .RP0_RX_W_FIFO_DEPTH       ( RP0_RX_W_FIFO_DEPTH          ),
@@ -355,6 +411,12 @@ import packet_def_pkg::*;
         .RP3_RX_W_FIFO_DEPTH       ( RP3_RX_W_FIFO_DEPTH          ),
         .RP3_RX_R_FIFO_DEPTH       ( RP3_RX_R_FIFO_DEPTH          ),
         .RP3_RX_B_FIFO_DEPTH       ( RP3_RX_B_FIFO_DEPTH          ),
+
+        .RX_AW_FIFO_RS_EN          ( RX_AW_FIFO_RS_EN             ),
+        .RX_AR_FIFO_RS_EN          ( RX_AR_FIFO_RS_EN             ),
+        .RX_W_FIFO_RS_EN           ( RX_W_FIFO_RS_EN              ),
+        .RX_R_FIFO_RS_EN           ( RX_R_FIFO_RS_EN              ),
+        .RX_B_FIFO_RS_EN           ( RX_B_FIFO_RS_EN              ),
 
         .RP0_AXI_DATA_WD           ( RP0_AXI_DATA_WD              ),
         .RP1_AXI_DATA_WD           ( RP1_AXI_DATA_WD              ),
@@ -472,31 +534,33 @@ import packet_def_pkg::*;
         .O_AOU_RX_AXI_S_BVALID      ( O_AOU_RX_AXI_S_BVALID         ),
         .I_AOU_RX_AXI_S_BREADY      ( I_AOU_RX_AXI_S_BREADY         ),
 
+        .I_FDI_PL_0_VALID            ( I_FDI_PL_0_VALID              ),
+        .I_FDI_PL_0_DATA             ( I_FDI_PL_0_DATA               ),
+        .I_FDI_PL_0_FLIT_CANCEL      ( I_FDI_PL_0_FLIT_CANCEL        ),
+
+        .I_FDI_PL_0_TRDY             ( I_FDI_PL_0_TRDY               ),
+        .I_FDI_PL_0_STALLREQ         ( I_FDI_PL_0_STALLREQ           ),
+        .I_FDI_PL_0_STATE_STS        ( I_FDI_PL_0_STATE_STS          ),
+        .O_FDI_LP_0_DATA             ( O_FDI_LP_0_DATA               ),
+        .O_FDI_LP_0_VALID            ( O_FDI_LP_0_VALID              ),
+        .O_FDI_LP_0_IRDY             ( O_FDI_LP_0_IRDY               ),
+        .O_FDI_LP_0_STALLACK         ( O_FDI_LP_0_STALLACK           ),
+
+`ifdef TWO_PHY
         .I_PHY_TYPE                  ( I_PHY_TYPE                    ),
 
-        .I_FDI_PL_32B_VALID          ( I_FDI_PL_32B_VALID            ),
-        .I_FDI_PL_32B_DATA           ( I_FDI_PL_32B_DATA             ),
-        .I_FDI_PL_32B_FLIT_CANCEL    ( I_FDI_PL_32B_FLIT_CANCEL      ),
+        .I_FDI_PL_1_VALID            ( I_FDI_PL_1_VALID              ),
+        .I_FDI_PL_1_DATA             ( I_FDI_PL_1_DATA               ),
+        .I_FDI_PL_1_FLIT_CANCEL      ( I_FDI_PL_1_FLIT_CANCEL        ),
 
-        .I_FDI_PL_64B_VALID          ( I_FDI_PL_64B_VALID            ),
-        .I_FDI_PL_64B_DATA           ( I_FDI_PL_64B_DATA             ),
-        .I_FDI_PL_64B_FLIT_CANCEL    ( I_FDI_PL_64B_FLIT_CANCEL      ),
-
-        .I_FDI_PL_32B_TRDY           ( I_FDI_PL_32B_TRDY             ),
-        .I_FDI_PL_32B_STALLREQ       ( I_FDI_PL_32B_STALLREQ         ),
-        .I_FDI_PL_32B_STATE_STS      ( I_FDI_PL_32B_STATE_STS        ),
-        .O_FDI_LP_32B_DATA           ( O_FDI_LP_32B_DATA             ),
-        .O_FDI_LP_32B_VALID          ( O_FDI_LP_32B_VALID            ),
-        .O_FDI_LP_32B_IRDY           ( O_FDI_LP_32B_IRDY             ),
-        .O_FDI_LP_32B_STALLACK       ( O_FDI_LP_32B_STALLACK         ),
-
-        .I_FDI_PL_64B_TRDY           ( I_FDI_PL_64B_TRDY             ),
-        .I_FDI_PL_64B_STALLREQ       ( I_FDI_PL_64B_STALLREQ         ),
-        .I_FDI_PL_64B_STATE_STS      ( I_FDI_PL_64B_STATE_STS        ),
-        .O_FDI_LP_64B_DATA           ( O_FDI_LP_64B_DATA             ),
-        .O_FDI_LP_64B_VALID          ( O_FDI_LP_64B_VALID            ),
-        .O_FDI_LP_64B_IRDY           ( O_FDI_LP_64B_IRDY             ),
-        .O_FDI_LP_64B_STALLACK       ( O_FDI_LP_64B_STALLACK         ),
+        .I_FDI_PL_1_TRDY             ( I_FDI_PL_1_TRDY               ),
+        .I_FDI_PL_1_STALLREQ         ( I_FDI_PL_1_STALLREQ           ),
+        .I_FDI_PL_1_STATE_STS        ( I_FDI_PL_1_STATE_STS          ),
+        .O_FDI_LP_1_DATA             ( O_FDI_LP_1_DATA               ),
+        .O_FDI_LP_1_VALID            ( O_FDI_LP_1_VALID              ),
+        .O_FDI_LP_1_IRDY             ( O_FDI_LP_1_IRDY               ),
+        .O_FDI_LP_1_STALLACK         ( O_FDI_LP_1_STALLACK           ),
+`endif
 
         .INT_REQ_LINKRESET           ( INT_REQ_LINKRESET             ),
         .INT_SI0_ID_MISMATCH         ( INT_SI0_ID_MISMATCH           ),

--- a/RTL/AOU_TX_CORE.sv
+++ b/RTL/AOU_TX_CORE.sv
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -25,7 +26,7 @@
 
 `timescale 1ns/1ps
 
-import packet_def_pkg::*; 
+import packet_def_pkg::*;
 module AOU_TX_CORE
 
 #(
@@ -33,7 +34,7 @@ module AOU_TX_CORE
     parameter   RP0_AXI_DATA_WD     = 512,
     parameter   RP1_AXI_DATA_WD     = 512,
     parameter   RP2_AXI_DATA_WD     = 512,
-    parameter   RP3_AXI_DATA_WD     = 512, 
+    parameter   RP3_AXI_DATA_WD     = 512,
     parameter   MAX_AXI_DATA_WD     = 1024,
     parameter   AXI_ADDR_WD         = 64,
     parameter   AXI_ID_WD           = 10,
@@ -84,7 +85,7 @@ module AOU_TX_CORE
     localparam  AOU_TX_R_FIFO_DEPTH   = 2,
     localparam  AOU_MISC_FIFO_DEPTH   = 2
 )
-( 
+(
     input  logic                                                I_CLK,
     input  logic                                                I_RESETN,
 
@@ -101,7 +102,7 @@ module AOU_TX_CORE
     input  logic    [RP_CNT-1:0][2:0]                           I_AOU_TX_AXI_AWPROT,
     input  logic    [RP_CNT-1:0][3:0]                           I_AOU_TX_AXI_AWQOS,
     input  logic    [RP_CNT-1:0]                                I_AOU_TX_AXI_AWVALID,
-    output logic    [RP_CNT-1:0]                                O_AOU_TX_AXI_AWREADY,      
+    output logic    [RP_CNT-1:0]                                O_AOU_TX_AXI_AWREADY,
 
     input  logic    [RP_CNT-1:0][MAX_AXI_DATA_WD-1:0]           I_AOU_TX_AXI_WDATA,
     input  logic    [RP_CNT-1:0][MAX_AXI_STRB_WD-1:0]           I_AOU_TX_AXI_WSTRB,
@@ -197,7 +198,7 @@ module AOU_TX_CORE
 
     //Interface for TX Credit - transaction valid
     output logic    [RP_CNT-1:0]                                O_AOU_TX_WREQVALID,
-    output logic    [RP_CNT-1:0]                                O_AOU_TX_RREQVALID, 
+    output logic    [RP_CNT-1:0]                                O_AOU_TX_RREQVALID,
     output logic    [RP_CNT-1:0]                                O_AOU_TX_WDATAVALID,
     output logic    [RP_CNT-1:0]                                O_AOU_TX_WFDATA,
     output logic    [RP_CNT-1:0]                                O_AOU_TX_RDATAVALID,
@@ -208,7 +209,7 @@ module AOU_TX_CORE
     input  logic                                                I_AOU_WRITEFULL_MSGTYPE_EN,
 
     input  logic    [7:0]                                       I_AOU_TX_LP_MODE_THRESHOLD,
-    input  logic                                                I_AOU_TX_LP_MODE,           
+    input  logic                                                I_AOU_TX_LP_MODE,
 
     //Interface for FDI
     input  logic                                                I_FDI_PL_TRDY_0,
@@ -226,43 +227,32 @@ module AOU_TX_CORE
 
     input  logic                                                I_STATUS_DISABLED,
     input  logic [3:0][1:0]                                     I_RP_DEST_RP,
-    input  logic [3:0]                                          I_PRIOR_RP_AXI_AXI_QOS_TO_NP,    
-    input  logic [3:0]                                          I_PRIOR_RP_AXI_AXI_QOS_TO_HP,    
-    input  logic [1:0]                                          I_PRIOR_RP_AXI_RP3_PRIOR,    
-    input  logic [1:0]                                          I_PRIOR_RP_AXI_RP2_PRIOR,    
-    input  logic [1:0]                                          I_PRIOR_RP_AXI_RP1_PRIOR,    
-    input  logic [1:0]                                          I_PRIOR_RP_AXI_RP0_PRIOR,    
-    input  logic [1:0]                                          I_PRIOR_RP_AXI_ARB_MODE,    
-    input  logic [15:0]                                         I_PRIOR_TIMER_TIMER_RESOLUTION,    
-    input  logic [15:0]                                         I_PRIOR_TIMER_TIMER_THRESHOLD       
+    input  logic [3:0]                                          I_PRIOR_RP_AXI_AXI_QOS_TO_NP,
+    input  logic [3:0]                                          I_PRIOR_RP_AXI_AXI_QOS_TO_HP,
+    input  logic [1:0]                                          I_PRIOR_RP_AXI_RP3_PRIOR,
+    input  logic [1:0]                                          I_PRIOR_RP_AXI_RP2_PRIOR,
+    input  logic [1:0]                                          I_PRIOR_RP_AXI_RP1_PRIOR,
+    input  logic [1:0]                                          I_PRIOR_RP_AXI_RP0_PRIOR,
+    input  logic [1:0]                                          I_PRIOR_RP_AXI_ARB_MODE,
+    input  logic [15:0]                                         I_PRIOR_TIMER_TIMER_RESOLUTION,
+    input  logic [15:0]                                         I_PRIOR_TIMER_TIMER_THRESHOLD
 
 );
-`ifdef FDI_128B
-    `define AOU_FDI_PACK_2STEP
-    localparam int FLIT_PACK_STATE_W = 1;
-    localparam int FLIT_PACK_GRANULE_CNT = 24;
-    localparam logic FLIT_LAST_PACK_STATE = 1'b1;
-`elsif FDI_64B
-    `define AOU_FDI_PACK_4STEP
-    localparam int FLIT_PACK_STATE_W = 2;
-    localparam int FLIT_PACK_GRANULE_CNT = 12;
-    localparam logic [1:0] FLIT_LAST_PACK_STATE = 2'b11;
-`elsif FDI_32B
-    `define AOU_FDI_PACK_4STEP
-    localparam int FLIT_PACK_STATE_W = 2;
-    localparam int FLIT_PACK_GRANULE_CNT = 12;
-    localparam logic [1:0] FLIT_LAST_PACK_STATE = 2'b11;
-`else
-    `define AOU_FDI_PACK_4STEP
-    localparam int FLIT_PACK_STATE_W = 2;
-    localparam int FLIT_PACK_GRANULE_CNT = 12;
-    localparam logic [1:0] FLIT_LAST_PACK_STATE = 2'b11;
-`endif
+// Flit-packing parameters derived from FDI data width.
+//   "Active" width for packing = max(FDI_IF_WD0, FDI_IF_WD1) so both
+//   single-PHY (WD1 defaults to 512) and two-PHY configurations select the
+//   same packing pipeline depth as the original FDI_*B defines:
+//     FDI_PACK_WD == 1024 -> 2-step pack (half-flit at a time, 24 granules)
+//     FDI_PACK_WD <= 512  -> 4-step pack (quarter-flit at a time, 12 granules)
+localparam int FDI_PACK_WD           = (FDI_IF_WD0 > FDI_IF_WD1) ? FDI_IF_WD0 : FDI_IF_WD1;
+localparam int FLIT_PACK_STATE_W     = (FDI_PACK_WD == 1024) ? 1 : 2;
+localparam int FLIT_PACK_GRANULE_CNT = (FDI_PACK_WD == 1024) ? 24 : 12;
+localparam logic [FLIT_PACK_STATE_W-1:0] FLIT_LAST_PACK_STATE = {FLIT_PACK_STATE_W{1'b1}};
 
 localparam RP0_NO_STRB_W_G_SIZE  = (RP0_AXI_DATA_WD == 256) ? WF256b_G  :
                                     (RP0_AXI_DATA_WD == 512) ? WF512b_G  :
                                     (RP0_AXI_DATA_WD == 1024)? WF1024b_G : 0;
-                            
+
 localparam RP0_W_G_SIZE          = (RP0_AXI_DATA_WD == 256) ? W256b_G  :
                                     (RP0_AXI_DATA_WD == 512) ? W512b_G  :
                                     (RP0_AXI_DATA_WD == 1024)? W1024b_G : 0;
@@ -270,7 +260,7 @@ localparam RP0_W_G_SIZE          = (RP0_AXI_DATA_WD == 256) ? W256b_G  :
 localparam RP1_NO_STRB_W_G_SIZE  = (RP1_AXI_DATA_WD == 256) ? WF256b_G  :
                                     (RP1_AXI_DATA_WD == 512) ? WF512b_G  :
                                     (RP1_AXI_DATA_WD == 1024)? WF1024b_G : 0;
-                            
+
 localparam RP1_W_G_SIZE          = (RP1_AXI_DATA_WD == 256) ? W256b_G  :
                                     (RP1_AXI_DATA_WD == 512) ? W512b_G  :
                                     (RP1_AXI_DATA_WD == 1024)? W1024b_G : 0;
@@ -278,7 +268,7 @@ localparam RP1_W_G_SIZE          = (RP1_AXI_DATA_WD == 256) ? W256b_G  :
 localparam RP2_NO_STRB_W_G_SIZE  = (RP2_AXI_DATA_WD == 256) ? WF256b_G  :
                                     (RP2_AXI_DATA_WD == 512) ? WF512b_G  :
                                     (RP2_AXI_DATA_WD == 1024)? WF1024b_G : 0;
-                            
+
 localparam RP2_W_G_SIZE          = (RP2_AXI_DATA_WD == 256) ? W256b_G  :
                                     (RP2_AXI_DATA_WD == 512) ? W512b_G  :
                                     (RP2_AXI_DATA_WD == 1024)? W1024b_G : 0;
@@ -286,15 +276,15 @@ localparam RP2_W_G_SIZE          = (RP2_AXI_DATA_WD == 256) ? W256b_G  :
 localparam RP3_NO_STRB_W_G_SIZE  = (RP3_AXI_DATA_WD == 256) ? WF256b_G  :
                                     (RP3_AXI_DATA_WD == 512) ? WF512b_G  :
                                     (RP3_AXI_DATA_WD == 1024)? WF1024b_G : 0;
-                            
+
 localparam RP3_W_G_SIZE          = (RP3_AXI_DATA_WD == 256) ? W256b_G  :
                                     (RP3_AXI_DATA_WD == 512) ? W512b_G  :
-                                    (RP3_AXI_DATA_WD == 1024)? W1024b_G : 0;     
+                                    (RP3_AXI_DATA_WD == 1024)? W1024b_G : 0;
 
 localparam int RP_AXI_DATA_WD [4] = '{RP0_AXI_DATA_WD, RP1_AXI_DATA_WD, RP2_AXI_DATA_WD, RP3_AXI_DATA_WD};
 localparam int RP_AXI_STRB_WD [4] = '{RP0_AXI_STRB_WD, RP1_AXI_STRB_WD, RP2_AXI_STRB_WD, RP3_AXI_STRB_WD};
 localparam int RP_W_G_SIZE [4] = '{RP0_W_G_SIZE, RP1_W_G_SIZE, RP2_W_G_SIZE, RP3_W_G_SIZE};
-localparam int RP_NO_STRB_W_G_SIZE [4] = '{RP0_NO_STRB_W_G_SIZE, RP1_NO_STRB_W_G_SIZE, RP2_NO_STRB_W_G_SIZE, RP3_NO_STRB_W_G_SIZE};                     
+localparam int RP_NO_STRB_W_G_SIZE [4] = '{RP0_NO_STRB_W_G_SIZE, RP1_NO_STRB_W_G_SIZE, RP2_NO_STRB_W_G_SIZE, RP3_NO_STRB_W_G_SIZE};
 
 localparam RING_DEPTH = 128;
 localparam RING_CNT   = $clog2(RING_DEPTH+1);
@@ -310,7 +300,7 @@ logic   [3:0]                   w_aou_fifo_awcache;
 logic   [2:0]                   w_aou_fifo_awprot;
 logic   [3:0]                   w_aou_fifo_awqos;
 logic                           w_aou_fifo_awvalid;
-logic                           w_aou_fifo_awready; 
+logic                           w_aou_fifo_awready;
 
 logic   [MAX_AXI_DATA_WD-1:0]   w_aou_fifo_wdata;
 logic   [MAX_AXI_STRB_WD-1:0]   w_aou_fifo_wstrb;
@@ -359,9 +349,9 @@ logic                           w_aou_tx_axi_hs;
 integer unsigned i, j;
 
 logic   w_aou_fifo_ar_hs;
-logic   w_aou_fifo_aw_hs; 
-logic   w_aou_fifo_w_hs;  
-logic   w_aou_fifo_b_hs;  
+logic   w_aou_fifo_aw_hs;
+logic   w_aou_fifo_w_hs;
+logic   w_aou_fifo_b_hs;
 logic   w_aou_fifo_r_hs;
 logic   w_aou_fifo_misc_crd_hs;
 logic   w_aou_fifo_misc_act_hs;
@@ -491,7 +481,7 @@ end
 assign w_ring_buffer_ready = (((r_cur_granule_start - r_cur_flit_for_fifo_start) & 8'b1111_1111 ) < (128 - (AW_G + w_wdata_granule_size + B_G + AR_G + w_rdata_granule_size) ));
 
 assign w_aou_fifo_awready   = w_ring_buffer_ready && (!w_misc_activation_valid) && w_flit_fifo_ready;
-assign w_aou_fifo_wready    = w_ring_buffer_ready && (!w_misc_activation_valid) && w_flit_fifo_ready; 
+assign w_aou_fifo_wready    = w_ring_buffer_ready && (!w_misc_activation_valid) && w_flit_fifo_ready;
 assign w_aou_fifo_bready    = w_ring_buffer_ready && (!w_misc_activation_valid) && w_flit_fifo_ready;
 assign w_aou_fifo_arready   = w_ring_buffer_ready && (!w_misc_activation_valid) && w_flit_fifo_ready;
 assign w_aou_fifo_rready    = w_ring_buffer_ready && (!w_misc_activation_valid) && w_flit_fifo_ready;
@@ -518,7 +508,7 @@ AOU_TX_AXI_BUFFER
     .AXI_ADDR_WD             ( AXI_ADDR_WD           ),
     .AXI_ID_WD               ( AXI_ID_WD             ),
     .AXI_LEN_WD              ( AXI_LEN_WD            ),
-    .MAX_AXI_DATA_WD         ( MAX_AXI_DATA_WD       ), 
+    .MAX_AXI_DATA_WD         ( MAX_AXI_DATA_WD       ),
 
     .AXI_AW_FIFO_DEPTH       ( AOU_TX_AW_FIFO_DEPTH  ),
     .AXI_W_FIFO_DEPTH        ( AOU_TX_W_FIFO_DEPTH   ),
@@ -526,31 +516,31 @@ AOU_TX_AXI_BUFFER
     .AXI_AR_FIFO_DEPTH       ( AOU_TX_AR_FIFO_DEPTH  ),
     .AXI_R_FIFO_DEPTH        ( AOU_TX_R_FIFO_DEPTH   ),
 
-    .CNT_RP0_AW_MAX_CREDIT   ( CNT_RP0_AW_MAX_CREDIT ),   
-    .CNT_RP0_W_MAX_CREDIT    ( CNT_RP0_W_MAX_CREDIT  ),   
-    .CNT_RP0_B_MAX_CREDIT    ( CNT_RP0_B_MAX_CREDIT  ),   
-    .CNT_RP0_AR_MAX_CREDIT   ( CNT_RP0_AR_MAX_CREDIT ),   
-    .CNT_RP0_R_MAX_CREDIT    ( CNT_RP0_R_MAX_CREDIT  ),   
-                                                   
-    .CNT_RP1_AW_MAX_CREDIT   ( CNT_RP1_AW_MAX_CREDIT ),   
-    .CNT_RP1_W_MAX_CREDIT    ( CNT_RP1_W_MAX_CREDIT  ),   
-    .CNT_RP1_B_MAX_CREDIT    ( CNT_RP1_B_MAX_CREDIT  ),   
-    .CNT_RP1_AR_MAX_CREDIT   ( CNT_RP1_AR_MAX_CREDIT ),   
-    .CNT_RP1_R_MAX_CREDIT    ( CNT_RP1_R_MAX_CREDIT  ),   
-                                                   
-    .CNT_RP2_AW_MAX_CREDIT   ( CNT_RP2_AW_MAX_CREDIT ),   
-    .CNT_RP2_W_MAX_CREDIT    ( CNT_RP2_W_MAX_CREDIT  ),   
-    .CNT_RP2_B_MAX_CREDIT    ( CNT_RP2_B_MAX_CREDIT  ),   
-    .CNT_RP2_AR_MAX_CREDIT   ( CNT_RP2_AR_MAX_CREDIT ),   
-    .CNT_RP2_R_MAX_CREDIT    ( CNT_RP2_R_MAX_CREDIT  ),   
-                                                   
-    .CNT_RP3_AW_MAX_CREDIT   ( CNT_RP3_AW_MAX_CREDIT ),   
-    .CNT_RP3_W_MAX_CREDIT    ( CNT_RP3_W_MAX_CREDIT  ),   
-    .CNT_RP3_B_MAX_CREDIT    ( CNT_RP3_B_MAX_CREDIT  ),   
-    .CNT_RP3_AR_MAX_CREDIT   ( CNT_RP3_AR_MAX_CREDIT ),   
-    .CNT_RP3_R_MAX_CREDIT    ( CNT_RP3_R_MAX_CREDIT  )   
+    .CNT_RP0_AW_MAX_CREDIT   ( CNT_RP0_AW_MAX_CREDIT ),
+    .CNT_RP0_W_MAX_CREDIT    ( CNT_RP0_W_MAX_CREDIT  ),
+    .CNT_RP0_B_MAX_CREDIT    ( CNT_RP0_B_MAX_CREDIT  ),
+    .CNT_RP0_AR_MAX_CREDIT   ( CNT_RP0_AR_MAX_CREDIT ),
+    .CNT_RP0_R_MAX_CREDIT    ( CNT_RP0_R_MAX_CREDIT  ),
+
+    .CNT_RP1_AW_MAX_CREDIT   ( CNT_RP1_AW_MAX_CREDIT ),
+    .CNT_RP1_W_MAX_CREDIT    ( CNT_RP1_W_MAX_CREDIT  ),
+    .CNT_RP1_B_MAX_CREDIT    ( CNT_RP1_B_MAX_CREDIT  ),
+    .CNT_RP1_AR_MAX_CREDIT   ( CNT_RP1_AR_MAX_CREDIT ),
+    .CNT_RP1_R_MAX_CREDIT    ( CNT_RP1_R_MAX_CREDIT  ),
+
+    .CNT_RP2_AW_MAX_CREDIT   ( CNT_RP2_AW_MAX_CREDIT ),
+    .CNT_RP2_W_MAX_CREDIT    ( CNT_RP2_W_MAX_CREDIT  ),
+    .CNT_RP2_B_MAX_CREDIT    ( CNT_RP2_B_MAX_CREDIT  ),
+    .CNT_RP2_AR_MAX_CREDIT   ( CNT_RP2_AR_MAX_CREDIT ),
+    .CNT_RP2_R_MAX_CREDIT    ( CNT_RP2_R_MAX_CREDIT  ),
+
+    .CNT_RP3_AW_MAX_CREDIT   ( CNT_RP3_AW_MAX_CREDIT ),
+    .CNT_RP3_W_MAX_CREDIT    ( CNT_RP3_W_MAX_CREDIT  ),
+    .CNT_RP3_B_MAX_CREDIT    ( CNT_RP3_B_MAX_CREDIT  ),
+    .CNT_RP3_AR_MAX_CREDIT   ( CNT_RP3_AR_MAX_CREDIT ),
+    .CNT_RP3_R_MAX_CREDIT    ( CNT_RP3_R_MAX_CREDIT  )
 ) u_aou_tx_axi_buffer
-( 
+(
     .I_CLK                                  ( I_CLK                         ),
     .I_RESETN                               ( I_RESETN                      ),
 
@@ -565,7 +555,7 @@ AOU_TX_AXI_BUFFER
     .I_AOU_TX_S_AXI_AWPROT                  ( I_AOU_TX_AXI_AWPROT           ),
     .I_AOU_TX_S_AXI_AWQOS                   ( I_AOU_TX_AXI_AWQOS            ),
     .I_AOU_TX_S_AXI_AWVALID                 ( I_AOU_TX_AXI_AWVALID          ),
-    .O_AOU_TX_S_AXI_AWREADY                 ( O_AOU_TX_AXI_AWREADY          ),      
+    .O_AOU_TX_S_AXI_AWREADY                 ( O_AOU_TX_AXI_AWREADY          ),
 
     .I_AOU_TX_S_AXI_WDATA                   ( I_AOU_TX_AXI_WDATA            ),
     .I_AOU_TX_S_AXI_WSTRB                   ( I_AOU_TX_AXI_WSTRB            ),
@@ -624,7 +614,7 @@ AOU_TX_AXI_BUFFER
     .O_AOU_TX_M_AXI_BVALID                  ( w_aou_fifo_bvalid             ),
     .I_AOU_TX_M_AXI_BREADY                  ( w_aou_fifo_bready             ),
 
-    .O_AOU_TX_M_AXI_AR_MESSAGE              ( w_aou_tx_m_axi_ar_message     ), 
+    .O_AOU_TX_M_AXI_AR_MESSAGE              ( w_aou_tx_m_axi_ar_message     ),
     .O_AOU_TX_M_AXI_ARVALID                 ( w_aou_fifo_arvalid            ),
     .I_AOU_TX_M_AXI_ARREADY                 ( w_aou_fifo_arready            ),
 
@@ -646,20 +636,20 @@ AOU_TX_AXI_BUFFER
     .O_AOU_TX_RDATAVALID                    ( O_AOU_TX_RDATAVALID           ),
     .O_AOU_TX_RDATA_DLENGTH                 ( O_AOU_TX_RDATA_DLENGTH        ),
     .O_AOU_TX_WRESPVALID                    ( O_AOU_TX_WRESPVALID           ),
-    
+
     .I_RP_DEST_RP                           ( I_RP_DEST_RP                  ),
 
-    .I_PRIOR_RP_AXI_AXI_QOS_TO_NP           (I_PRIOR_RP_AXI_AXI_QOS_TO_NP    ), 
-    .I_PRIOR_RP_AXI_AXI_QOS_TO_HP           (I_PRIOR_RP_AXI_AXI_QOS_TO_HP    ), 
-    .I_PRIOR_RP_AXI_RP3_PRIOR               (I_PRIOR_RP_AXI_RP3_PRIOR        ), 
-    .I_PRIOR_RP_AXI_RP2_PRIOR               (I_PRIOR_RP_AXI_RP2_PRIOR        ), 
-    .I_PRIOR_RP_AXI_RP1_PRIOR               (I_PRIOR_RP_AXI_RP1_PRIOR        ), 
-    .I_PRIOR_RP_AXI_RP0_PRIOR               (I_PRIOR_RP_AXI_RP0_PRIOR        ), 
-    .I_PRIOR_RP_AXI_ARB_MODE                (I_PRIOR_RP_AXI_ARB_MODE         ), 
+    .I_PRIOR_RP_AXI_AXI_QOS_TO_NP           (I_PRIOR_RP_AXI_AXI_QOS_TO_NP    ),
+    .I_PRIOR_RP_AXI_AXI_QOS_TO_HP           (I_PRIOR_RP_AXI_AXI_QOS_TO_HP    ),
+    .I_PRIOR_RP_AXI_RP3_PRIOR               (I_PRIOR_RP_AXI_RP3_PRIOR        ),
+    .I_PRIOR_RP_AXI_RP2_PRIOR               (I_PRIOR_RP_AXI_RP2_PRIOR        ),
+    .I_PRIOR_RP_AXI_RP1_PRIOR               (I_PRIOR_RP_AXI_RP1_PRIOR        ),
+    .I_PRIOR_RP_AXI_RP0_PRIOR               (I_PRIOR_RP_AXI_RP0_PRIOR        ),
+    .I_PRIOR_RP_AXI_ARB_MODE                (I_PRIOR_RP_AXI_ARB_MODE         ),
     .I_PRIOR_TIMER_TIMER_RESOLUTION         (I_PRIOR_TIMER_TIMER_RESOLUTION  ),
     .I_PRIOR_TIMER_TIMER_THRESHOLD          (I_PRIOR_TIMER_TIMER_THRESHOLD   ),
 
-    .I_AOU_WRITEFULL_MSGTYPE_EN             (I_AOU_WRITEFULL_MSGTYPE_EN      ) 
+    .I_AOU_WRITEFULL_MSGTYPE_EN             (I_AOU_WRITEFULL_MSGTYPE_EN      )
 
 
 
@@ -668,7 +658,7 @@ AOU_TX_AXI_BUFFER
 AOU_SYNC_FIFO_REG
 #(
     .FIFO_WIDTH                     (56),
-    .FIFO_DEPTH                     (AOU_MISC_FIFO_DEPTH)        
+    .FIFO_DEPTH                     (AOU_MISC_FIFO_DEPTH)
 )
 u_aou_misc_crdtgrant_tx_fifo(
     .I_CLK                          (I_CLK),
@@ -683,7 +673,7 @@ u_aou_misc_crdtgrant_tx_fifo(
     .O_SREADY                       (O_AOU_CRDTGRANT_READY),
 
     .I_MREADY                       (w_misc_crdtgrant_fifo_ready),
-    .O_MDATA                        (w_misc_crdtgrant_payload),  
+    .O_MDATA                        (w_misc_crdtgrant_payload),
     .O_MVALID                       (w_misc_crdtgrant_fifo_valid),
 
     .O_EMPTY_CNT                    (),
@@ -694,7 +684,7 @@ u_aou_misc_crdtgrant_tx_fifo(
 AOU_SYNC_FIFO_REG
 #(
     .FIFO_WIDTH                     (4 + 1),
-    .FIFO_DEPTH                     (AOU_MISC_FIFO_DEPTH)        
+    .FIFO_DEPTH                     (AOU_MISC_FIFO_DEPTH)
 )
 u_misc_activate_fifo(
     .I_CLK                          (I_CLK),
@@ -705,7 +695,7 @@ u_misc_activate_fifo(
     .O_SREADY                       (O_AOU_ACTIVATION_READY),
 
     .I_MREADY                       (w_misc_activation_ready),
-    .O_MDATA                        ({w_misc_activation_op, w_misc_activation_prop_req}),  
+    .O_MDATA                        ({w_misc_activation_op, w_misc_activation_prop_req}),
     .O_MVALID                       (w_misc_activation_valid),
 
     .O_EMPTY_CNT                    (),
@@ -728,7 +718,7 @@ AOU_FWD_RS #(
     .I_RESETN        ( I_RESETN                     ),
 
     .I_SVALID        ( I_AOU_MSGCREDIT_CRED_VALID        ),
-    .I_SDATA         ( {I_AOU_MSGCREDIT_RP, I_AOU_MSGCREDIT_WRESPCRED, I_AOU_MSGCREDIT_RDATACRED, 
+    .I_SDATA         ( {I_AOU_MSGCREDIT_RP, I_AOU_MSGCREDIT_WRESPCRED, I_AOU_MSGCREDIT_RDATACRED,
                     I_AOU_MSGCREDIT_WDATACRED, I_AOU_MSGCREDIT_RREQCRED, I_AOU_MSGCREDIT_WREQCRED}),
     .O_SREADY        ( O_AOU_MSGCREDIT_CRED_READY        ),
 
@@ -801,13 +791,13 @@ always_ff @ (posedge I_CLK or negedge I_RESETN) begin
         r_msgstart_buffer <= nxt_msgstart_buffer ;
 
         r_cur_granule_start <= nxt_granule_start;
-        
+
     end
 end
 
 always_comb begin
-    nxt_granule_buffer = r_granule_buffer; 
-    nxt_msgstart_buffer = r_msgstart_buffer; 
+    nxt_granule_buffer = r_granule_buffer;
+    nxt_msgstart_buffer = r_msgstart_buffer;
 
     if (w_aou_fifo_aw_hs) begin
         for (int unsigned n=0; n < AW_G; n++) begin
@@ -828,7 +818,7 @@ always_comb begin
                     for (int unsigned n=0; n < RP_W_G_SIZE[i]; n++) begin
                         nxt_granule_buffer[add_idx(w_w_message_start_idx, n)] = w_writedata_message[n*40 +: 40];
                         nxt_msgstart_buffer[add_idx(w_w_message_start_idx, n)] = (n == 0);
-                    end  
+                    end
                 end
             end
         end
@@ -838,14 +828,14 @@ always_comb begin
         for (int unsigned n=0; n < B_G; n++) begin
             nxt_granule_buffer[add_idx(w_b_message_start_idx, n)] = w_writeresp_message[n*40 +: 40];
             nxt_msgstart_buffer[add_idx(w_b_message_start_idx, n)] = (n == 0);
-        end 
+        end
     end
 
     if (w_aou_fifo_ar_hs) begin
         for (int unsigned n=0; n < AR_G; n++) begin
             nxt_granule_buffer[add_idx(w_ar_message_start_idx, n)] = w_readreq_message[n*40 +: 40];
             nxt_msgstart_buffer[add_idx(w_ar_message_start_idx, n)] = (n == 0);
-        end 
+        end
     end
 
     if (w_aou_fifo_r_hs) begin
@@ -858,12 +848,12 @@ always_comb begin
             for (int unsigned n=0; n < R512b_G; n++) begin
                 nxt_granule_buffer[add_idx(w_r_message_start_idx, n)] = w_readdata512b_message[n*40 +: 40];
                 nxt_msgstart_buffer[add_idx(w_r_message_start_idx, n)] = (n == 0);
-            end 
+            end
         end else begin
             for (int unsigned n=0; n < R1024b_G; n++) begin
                 nxt_granule_buffer[add_idx(w_r_message_start_idx, n)] = w_readdata1024b_message[n*40 +: 40];
                 nxt_msgstart_buffer[add_idx(w_r_message_start_idx, n)] = (n == 0);
-            end         
+            end
         end
     end
 
@@ -871,14 +861,14 @@ always_comb begin
         for (int unsigned n=0; n < 2; n++) begin
             nxt_granule_buffer[add_idx(w_misc_crdt_start_idx, n)] = w_misc_crdtgrant_message[n*40 +: 40];
             nxt_msgstart_buffer[add_idx(w_misc_crdt_start_idx, n)] = (n == 0);
-        end 
+        end
     end
 
     if (w_aou_fifo_misc_act_hs) begin
         for (int unsigned n=0; n < 1; n++) begin
             nxt_granule_buffer[add_idx(w_misc_activate_start_idx, n)] = w_misc_activate_message[n*40 +: 40];
             nxt_msgstart_buffer[add_idx(w_misc_activate_start_idx, n)] = (n == 0);
-        end 
+        end
     end
 
 end
@@ -900,7 +890,7 @@ always_comb begin
         end else begin
             nxt_flit_for_fifo_start = r_cur_granule_start;
         end
-    end 
+    end
 end
 
 always_ff @ (posedge I_CLK or negedge I_RESETN) begin
@@ -942,23 +932,26 @@ end
 
 assign w_flit_fifo_valid_out_valid = (w_flit_fifo_valid_timeout == I_AOU_TX_LP_MODE_THRESHOLD);
 
-assign w_flit_fifo_valid = I_AOU_TX_LP_MODE ? (r_cur_granule_start != r_cur_flit_for_fifo_start) || (r_flit_packing_state != '0) ||  (r_tx_activation_valid && w_flit_fifo_valid_out_valid): 
+assign w_flit_fifo_valid = I_AOU_TX_LP_MODE ? (r_cur_granule_start != r_cur_flit_for_fifo_start) || (r_flit_packing_state != '0) ||  (r_tx_activation_valid && w_flit_fifo_valid_out_valid):
                                             (r_cur_granule_start != r_cur_flit_for_fifo_start) || (r_flit_packing_state != '0) || (r_tx_activation_valid);
 
 
-assign O_AOU_TX_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_aou_fifo_bvalid 
+assign O_AOU_TX_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_aou_fifo_bvalid
                         || w_aou_fifo_arvalid || w_aou_fifo_rvalid || (r_cur_granule_start != r_cur_flit_for_fifo_start) || w_aou_tx_axi_hs;
 
-assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_aou_fifo_bvalid || w_aou_fifo_arvalid || w_aou_fifo_rvalid 
+assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_aou_fifo_bvalid || w_aou_fifo_arvalid || w_aou_fifo_rvalid
                                 || w_aou_tx_axi_hs;
 
 
-`ifdef AOU_FDI_PACK_4STEP
+// Two parallel packing pipelines. Exactly one elaborates per config:
+//   FDI_PACK_WD == 1024 -> g_pack_2step (half-flit per cycle, 24 granules)
+//   otherwise           -> g_pack_4step (quarter-flit per cycle, 12 granules)
+generate if (FDI_PACK_WD != 1024) begin : g_pack_4step
     logic [64*8-1:0]    r_flit_fifo_data;
     logic [64*8-1:0]    w_flit_fifo_data;
     logic [16-1:0]      w_a_half_header;
     logic [16-1:0]      w_b_half_header;
-    
+
     always_ff @ (posedge I_CLK or negedge I_RESETN) begin
         if (!I_RESETN) begin
             r_flit_fifo_data <= 'd0;
@@ -966,13 +959,13 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
             r_flit_fifo_data <= w_flit_fifo_data;
         end
     end
-    
+
     always_comb begin
         //flit chunk
-    
+
         case (nxt_flit_packing_state)
             2'b00: begin
-                w_a_half_header[2*8-1:0] = 16'b0000_0000_1100_0000;  //flit header 
+                w_a_half_header[2*8-1:0] = 16'b0000_0000_1100_0000;  //flit header
             end
             2'b01: begin
                 w_a_half_header[0 +: 4] = 4'b0000; //RSVD
@@ -1000,7 +993,7 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                 end
             end
         endcase
-    
+
         case (nxt_flit_packing_state)
             2'b00: begin
                 for (int unsigned n=0; n<12; n++) begin
@@ -1022,7 +1015,7 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                     end else begin
                         w_b_half_header[4 + n +: 1] = 1'b0;
                     end
-                        
+
                 end
                 w_b_half_header[0 +: 4] = 4'b0000; //RSVD
             end
@@ -1031,10 +1024,10 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                 w_b_half_header[0 +: 16] = 16'b0;
             end
         endcase
-        
+
         w_flit_fifo_data[0 +: 16] = w_a_half_header;
         w_flit_fifo_data[64 * 8 -1 -: 16] = w_b_half_header;
-    
+
         for (int unsigned n=0; n<12; n++) begin
             if (n < ((nxt_granule_start - nxt_flit_for_fifo_start ) & 8'b1111_1111 )) begin
                 w_flit_fifo_data[16 + 40*n +: 40] = nxt_granule_buffer[(nxt_flit_for_fifo_start + n) & (8'b0111_1111)];
@@ -1042,13 +1035,15 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                 w_flit_fifo_data[16 + 40*n +: 40] = 40'b0;
             end
         end
-    
+
     end
-    
+
     assign w_aou_msgcredit_ready = w_flit_fifo_valid && w_flit_fifo_ready && (r_flit_packing_state == 2'b10);
-    
-   
+
+
     `ifdef TWO_PHY
+        // Two-PHY + 4-step packing (FDI_IF_WD0 = 256, FDI_IF_WD1 = 512):
+        //   out-mux splits flit across the two PHY streams, one REV_RS per PHY.
         logic                                w_fdi_pl_0_trdy;
         logic [FDI_IF_WD0-1:0]               w_fdi_lp_0_data;
         logic                                w_fdi_lp_0_valid;
@@ -1059,21 +1054,21 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
 
         AOU_TX_CORE_OUT_MUX #(
             .FDI_IF_WD           ( FDI_IF_WD1           )
-        ) u_aou_tx_core_out_mux_64b
+        ) u_aou_tx_core_out_mux
         (
             .I_CLK               ( I_CLK                ),
             .I_RESETN            ( I_RESETN             ),
-        
+
             .I_PHY_TYPE          ( I_PHY_TYPE           ),
-        
+
             .O_FDI_PL_TRDY       ( w_flit_fifo_ready    ),
             .I_FDI_LP_DATA       ( r_flit_fifo_data     ),
             .I_FDI_LP_VALID      ( w_flit_fifo_valid    ),
-        
+
             .I_FDI_PL_0_TRDY     ( w_fdi_pl_0_trdy      ),
             .O_FDI_LP_0_DATA     ( w_fdi_lp_0_data      ),
             .O_FDI_LP_0_VALID    ( w_fdi_lp_0_valid     ),
-        
+
             .I_FDI_PL_1_TRDY     ( w_fdi_pl_1_trdy      ),
             .O_FDI_LP_1_DATA     ( w_fdi_lp_1_data      ),
             .O_FDI_LP_1_VALID    ( w_fdi_lp_1_valid     )
@@ -1081,104 +1076,107 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
 
         AOU_REV_RS #(
             .DATA_WIDTH         (FDI_IF_WD0)
-        ) u_aou_tx_core_32b
+        ) u_aou_tx_core_phy0_rs
         (
             .I_CLK              ( I_CLK              ),
             .I_RESETN           ( I_RESETN           ),
-    
+
             .I_SVALID           ( w_fdi_lp_0_valid   ),
             .O_SREADY           ( w_fdi_pl_0_trdy    ),
             .I_SDATA            ( w_fdi_lp_0_data    ),
-    
+
             .O_MVALID           ( O_FDI_LP_VALID_0   ),
             .I_MREADY           ( I_FDI_PL_TRDY_0    ),
             .O_MDATA            ( O_FDI_LP_DATA_0    )
         );
-    
+
         AOU_REV_RS #(
             .DATA_WIDTH         (FDI_IF_WD1)
-        ) u_aou_tx_core_64b
+        ) u_aou_tx_core_phy1_rs
         (
             .I_CLK              ( I_CLK              ),
             .I_RESETN           ( I_RESETN           ),
-    
+
             .I_SVALID           ( w_fdi_lp_1_valid   ),
             .O_SREADY           ( w_fdi_pl_1_trdy    ),
             .I_SDATA            ( w_fdi_lp_1_data    ),
-    
+
             .O_MVALID           ( O_FDI_LP_VALID_1   ),
             .I_MREADY           ( I_FDI_PL_TRDY_1    ),
             .O_MDATA            ( O_FDI_LP_DATA_1    )
         );
-    `elsif FDI_32B
-        logic                                w_fdi_pl_0_trdy;
-        logic [FDI_IF_WD0-1:0]               w_fdi_lp_0_data;
-        logic                                w_fdi_lp_0_valid;
+    `else
+        // Single-PHY + 4-step packing. Two sub-cases:
+        //   FDI_IF_WD0 == 256 (FDI_32B): out-mux with PHY1 tied, one REV_RS
+        //   FDI_IF_WD0 == 512 (FDI_64B): direct REV_RS, no out-mux needed
+        if (FDI_IF_WD0 == 256) begin : g_sp_32b
+            logic                                w_fdi_pl_0_trdy;
+            logic [FDI_IF_WD0-1:0]               w_fdi_lp_0_data;
+            logic                                w_fdi_lp_0_valid;
 
-        AOU_TX_CORE_OUT_MUX #(
-            .FDI_IF_WD           ( FDI_IF_WD1           )
-        ) u_aou_tx_core_out_mux_64b
-        (
-            .I_CLK               ( I_CLK                ),
-            .I_RESETN            ( I_RESETN             ),
-        
-            .I_PHY_TYPE          ( 1'b0                 ),
-        
-            .O_FDI_PL_TRDY       ( w_flit_fifo_ready    ),
-            .I_FDI_LP_DATA       ( r_flit_fifo_data     ),
-            .I_FDI_LP_VALID      ( w_flit_fifo_valid    ),
-        
-            .I_FDI_PL_0_TRDY     ( w_fdi_pl_0_trdy      ),
-            .O_FDI_LP_0_DATA     ( w_fdi_lp_0_data      ),
-            .O_FDI_LP_0_VALID    ( w_fdi_lp_0_valid     ),
-        
-            .I_FDI_PL_1_TRDY     ( 1'b0                 ),
-            .O_FDI_LP_1_DATA     (                      ),
-            .O_FDI_LP_1_VALID    (                      )
-        );
-    
-        AOU_REV_RS #(
-            .DATA_WIDTH         (FDI_IF_WD0)
-        ) u_aou_tx_core_32b
-        (
-            .I_CLK              ( I_CLK                 ),
-            .I_RESETN           ( I_RESETN              ),
-    
-            .I_SVALID           ( w_fdi_lp_0_valid      ),
-            .O_SREADY           ( w_fdi_pl_0_trdy       ),
-            .I_SDATA            ( w_fdi_lp_0_data       ),
-    
-            .O_MVALID           ( O_FDI_LP_VALID_0      ),
-            .I_MREADY           ( I_FDI_PL_TRDY_0       ),
-            .O_MDATA            ( O_FDI_LP_DATA_0       )
-        );
-    
-    `elsif FDI_64B
-    
-        AOU_REV_RS #(
-            .DATA_WIDTH         (FDI_IF_WD0)
-        ) u_aou_tx_core_64b
-        (
-            .I_CLK              ( I_CLK                 ),
-            .I_RESETN           ( I_RESETN              ),
-    
-            .I_SVALID           ( w_flit_fifo_valid     ),
-            .O_SREADY           ( w_flit_fifo_ready     ),
-            .I_SDATA            ( r_flit_fifo_data      ),
-    
-            .O_MVALID           ( O_FDI_LP_VALID_0      ),
-            .I_MREADY           ( I_FDI_PL_TRDY_0       ),
-            .O_MDATA            ( O_FDI_LP_DATA_0       )
-        );
+            AOU_TX_CORE_OUT_MUX #(
+                .FDI_IF_WD           ( FDI_IF_WD1           )
+            ) u_aou_tx_core_out_mux
+            (
+                .I_CLK               ( I_CLK                ),
+                .I_RESETN            ( I_RESETN             ),
+
+                .I_PHY_TYPE          ( 1'b0                 ),
+
+                .O_FDI_PL_TRDY       ( w_flit_fifo_ready    ),
+                .I_FDI_LP_DATA       ( r_flit_fifo_data     ),
+                .I_FDI_LP_VALID      ( w_flit_fifo_valid    ),
+
+                .I_FDI_PL_0_TRDY     ( w_fdi_pl_0_trdy      ),
+                .O_FDI_LP_0_DATA     ( w_fdi_lp_0_data      ),
+                .O_FDI_LP_0_VALID    ( w_fdi_lp_0_valid     ),
+
+                .I_FDI_PL_1_TRDY     ( 1'b0                 ),
+                .O_FDI_LP_1_DATA     (                      ),
+                .O_FDI_LP_1_VALID    (                      )
+            );
+
+            AOU_REV_RS #(
+                .DATA_WIDTH         (FDI_IF_WD0)
+            ) u_aou_tx_core_phy0_rs
+            (
+                .I_CLK              ( I_CLK                 ),
+                .I_RESETN           ( I_RESETN              ),
+
+                .I_SVALID           ( w_fdi_lp_0_valid      ),
+                .O_SREADY           ( w_fdi_pl_0_trdy       ),
+                .I_SDATA            ( w_fdi_lp_0_data       ),
+
+                .O_MVALID           ( O_FDI_LP_VALID_0      ),
+                .I_MREADY           ( I_FDI_PL_TRDY_0       ),
+                .O_MDATA            ( O_FDI_LP_DATA_0       )
+            );
+        end else begin : g_sp_64b
+            AOU_REV_RS #(
+                .DATA_WIDTH         (FDI_IF_WD0)
+            ) u_aou_tx_core_phy0_rs
+            (
+                .I_CLK              ( I_CLK                 ),
+                .I_RESETN           ( I_RESETN              ),
+
+                .I_SVALID           ( w_flit_fifo_valid     ),
+                .O_SREADY           ( w_flit_fifo_ready     ),
+                .I_SDATA            ( r_flit_fifo_data      ),
+
+                .O_MVALID           ( O_FDI_LP_VALID_0      ),
+                .I_MREADY           ( I_FDI_PL_TRDY_0       ),
+                .O_MDATA            ( O_FDI_LP_DATA_0       )
+            );
+        end
     `endif
-    
 
-`elsif AOU_FDI_PACK_2STEP
+
+end else begin : g_pack_2step
     logic [64*8*2-1:0]    r_flit_fifo_data;
     logic [64*8*2-1:0]    w_flit_fifo_data;
     logic [16-1:0]      w_first_a_half_header, w_second_a_half_header;
     logic [16-1:0]      w_first_b_half_header, w_second_b_half_header;
-    
+
     always_ff @ (posedge I_CLK or negedge I_RESETN) begin
         if (!I_RESETN) begin
             r_flit_fifo_data <= 'd0;
@@ -1186,14 +1184,14 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
             r_flit_fifo_data <= w_flit_fifo_data;
         end
     end
-    
+
     always_comb begin
         //flit chunk
-    
+
         case (nxt_flit_packing_state)
             1'b0 : begin
-                w_first_a_half_header[2*8-1:0] = 16'b0000_0000_1100_0000;  //flit header 
-    
+                w_first_a_half_header[2*8-1:0] = 16'b0000_0000_1100_0000;  //flit header
+
                 w_second_a_half_header[0 +: 4] = 4'b0000; //RSVD
                 for (int unsigned n=0; n<12; n++) begin
                     if (n + 12< ((nxt_granule_start - nxt_flit_for_fifo_start) & 8'b1111_1111 )) begin
@@ -1206,7 +1204,7 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
             1'b1: begin
                 w_first_a_half_header[0 +: 16] = w_aou_msgcredit_valid ? {w_aou_rs_msgcredit_rp, w_aou_rs_msgcredit_wrespcred, w_aou_rs_msgcredit_rdatacred,
                                             w_aou_rs_msgcredit_wdatacred, w_aou_rs_msgcredit_rreqcred, w_aou_rs_msgcredit_wreqcred} : 16'b0;
-    
+
                 w_second_a_half_header[0+: 4] = 4'b0000; //RSVD
                 for (int unsigned n=0; n<12; n++) begin
                     if (n + 12 < ((nxt_granule_start - nxt_flit_for_fifo_start) & 8'b1111_1111 )) begin
@@ -1217,7 +1215,7 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                 end
             end
         endcase
-    
+
         case (nxt_flit_packing_state)
             'b0: begin
                 for (int unsigned n=0; n<12; n++) begin
@@ -1228,7 +1226,7 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                     end
                 end
                 w_first_b_half_header[0 +: 4] = 4'b0000; //RSVD
-    
+
                 w_second_b_half_header[0 +: 16] = 16'b0;
             end
             1'b1: begin
@@ -1238,20 +1236,20 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                     end else begin
                         w_first_b_half_header[4 + n +: 1] = 1'b0;
                     end
-                        
+
                 end
                 w_first_b_half_header[0 +: 4] = 4'b0000; //RSVD
-    
+
                 w_second_b_half_header[0 +: 16] = 16'b0;
             end
         endcase
-        
+
         w_flit_fifo_data[0 +: 16] = w_first_a_half_header;
         w_flit_fifo_data[64 * 8 -1 -: 16] = w_first_b_half_header;
-    
+
         w_flit_fifo_data[512 +: 16] = w_second_a_half_header;
         w_flit_fifo_data[512 + 64 * 8 -1 -: 16] = w_second_b_half_header;
-    
+
         for (int unsigned n=0; n<12; n++) begin
             if (n < ((nxt_granule_start - nxt_flit_for_fifo_start ) & 8'b1111_1111 )) begin
                 w_flit_fifo_data[16 + 40*n +: 40] = nxt_granule_buffer[(nxt_flit_for_fifo_start + n) & (8'b0111_1111)];
@@ -1259,7 +1257,7 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                 w_flit_fifo_data[16 + 40*n +: 40] = 40'b0;
             end
         end
-    
+
         for (int unsigned n=0; n<12; n++) begin
             if (n + 12 < ((nxt_granule_start - nxt_flit_for_fifo_start ) & 8'b1111_1111 )) begin
                 w_flit_fifo_data[512 + 16 + 40*n +: 40] = nxt_granule_buffer[(nxt_flit_for_fifo_start + n + 12) & (8'b0111_1111)];
@@ -1267,9 +1265,9 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
                 w_flit_fifo_data[512 + 16 + 40*n +: 40] = 40'b0;
             end
         end
-    
+
     end
-    
+
     assign w_aou_msgcredit_ready = w_flit_fifo_valid && w_flit_fifo_ready && (r_flit_packing_state == 1'b1);
 
     logic                                w_fdi_pl_0_trdy;
@@ -1281,81 +1279,80 @@ assign O_AOU_TX_AXI_TR_PENDING = w_aou_fifo_awvalid || w_aou_fifo_wvalid || w_ao
         logic                                w_fdi_pl_1_trdy;
         logic [FDI_IF_WD1-1:0]               w_fdi_lp_1_data;
         logic                                w_fdi_lp_1_valid;
-    
+
         AOU_TX_CORE_OUT_MUX #(
             .FDI_IF_WD           ( FDI_IF_WD1        )
-        ) u_aou_tx_core_out_mux_128b
+        ) u_aou_tx_core_out_mux
         (
             .I_CLK               ( I_CLK             ),
             .I_RESETN            ( I_RESETN          ),
-        
+
             .I_PHY_TYPE          ( I_PHY_TYPE        ),
-        
+
             .O_FDI_PL_TRDY       ( w_flit_fifo_ready ),
             .I_FDI_LP_DATA       ( r_flit_fifo_data  ),
             .I_FDI_LP_VALID      ( w_flit_fifo_valid ),
-        
+
             .I_FDI_PL_0_TRDY     ( w_fdi_pl_0_trdy   ),
             .O_FDI_LP_0_DATA     ( w_fdi_lp_0_data   ),
             .O_FDI_LP_0_VALID    ( w_fdi_lp_0_valid  ),
-        
+
             .I_FDI_PL_1_TRDY     ( w_fdi_pl_1_trdy   ),
             .O_FDI_LP_1_DATA     ( w_fdi_lp_1_data   ),
             .O_FDI_LP_1_VALID    ( w_fdi_lp_1_valid  )
         );
-        
+
         AOU_REV_RS #(
             .DATA_WIDTH         (FDI_IF_WD0)
-        ) u_aou_tx_core_64b
+        ) u_aou_tx_core_phy0_rs
         (
             .I_CLK              ( I_CLK              ),
             .I_RESETN           ( I_RESETN           ),
-        
+
             .I_SVALID           ( w_fdi_lp_0_valid   ),
             .O_SREADY           ( w_fdi_pl_0_trdy    ),
             .I_SDATA            ( w_fdi_lp_0_data    ),
-        
+
             .O_MVALID           ( O_FDI_LP_VALID_0   ),
             .I_MREADY           ( I_FDI_PL_TRDY_0    ),
             .O_MDATA            ( O_FDI_LP_DATA_0    )
         );
-        
+
         AOU_REV_RS #(
             .DATA_WIDTH         (FDI_IF_WD1)
-        ) u_aou_tx_core_128b
+        ) u_aou_tx_core_phy1_rs
         (
             .I_CLK              ( I_CLK              ),
             .I_RESETN           ( I_RESETN           ),
-        
+
             .I_SVALID           ( w_fdi_lp_1_valid   ),
             .O_SREADY           ( w_fdi_pl_1_trdy    ),
             .I_SDATA            ( w_fdi_lp_1_data    ),
-        
+
             .O_MVALID           ( O_FDI_LP_VALID_1   ),
             .I_MREADY           ( I_FDI_PL_TRDY_1    ),
             .O_MDATA            ( O_FDI_LP_DATA_1    )
         );
     `else
+        // Single-PHY + 2-step packing (FDI_IF_WD0 = 1024): direct REV_RS.
         AOU_REV_RS #(
             .DATA_WIDTH         (FDI_IF_WD0)
-        ) u_aou_tx_core_128b
+        ) u_aou_tx_core_phy0_rs
         (
             .I_CLK              ( I_CLK                 ),
             .I_RESETN           ( I_RESETN              ),
-        
+
             .I_SVALID           ( w_flit_fifo_valid     ),
             .O_SREADY           ( w_flit_fifo_ready     ),
             .I_SDATA            ( r_flit_fifo_data      ),
-        
+
             .O_MVALID           ( O_FDI_LP_VALID_0      ),
             .I_MREADY           ( I_FDI_PL_TRDY_0       ),
             .O_MDATA            ( O_FDI_LP_DATA_0       )
         );
-        `endif
+    `endif
 
-`else
-
-`endif
+end endgenerate
 
 endmodule
 

--- a/RTL/filelist.f
+++ b/RTL/filelist.f
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -22,10 +23,15 @@
 //  Author     : Soyoung Min, Jaeyun Lee, Hojun Lee, Kwanho Kim
 //
 // *****************************************************************************
-+define+TWO_PHY
-+define+FDI_32B
-+define+FDI_64B
-//+define+FDI_128B
+// FDI data widths are now SystemVerilog parameters (FDI_IF_WD0 / FDI_IF_WD1)
+// on AOU_CORE_TOP and AOU_TOP. The +define+FDI_32B / FDI_64B / FDI_128B
+// preprocessor switches have been removed; override the parameters at the
+// top-level instantiation instead.
+//
+// TWO_PHY is intentionally NOT defined here: the parameter-refactor scope is
+// single-PHY only. AOU_TOP and AOU_CORE_TOP both wrap the second-PHY ports
+// and the I_PHY_TYPE port in `ifdef TWO_PHY` so the single-PHY build does
+// not require it. TWO_PHY enablement is tracked in a separate change.
 
 ${AOU_CORE_HOME}/RTL/packet_def_pkg.sv
 ${AOU_CORE_HOME}/RTL/AOU_RX_CORE.sv

--- a/RTL/packet_def_pkg.sv
+++ b/RTL/packet_def_pkg.sv
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // *****************************************************************************
 //  Copyright (c) 2026 BOS Semiconductors
+//  Copyright (c) 2026 Tenstorrent USA Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -45,6 +46,37 @@ parameter AR_G              = 3;
 parameter R256b_G           = 8;
 parameter R512b_G           = 14;
 parameter R1024b_G          = 27;
+
+// ----------------------------------------------------------------------------
+// FDI configuration selectors.
+//
+// FDI_CONFIG is a single integer parameter on AOU_TOP / AOU_CORE_TOP that
+// replaces the legacy FDI_IF_WD0 / FDI_IF_WD1 width pair. The selected value
+// determines the internally-derived FDI_IF_WD0 (always-present PHY0) and
+// FDI_IF_WD1 (PHY1, gated by `+define+TWO_PHY`) widths in bits.
+//
+// SP_* values describe a single-PHY configuration (no `+define+TWO_PHY`).
+// TP_* values describe a two-PHY configuration and require `+define+TWO_PHY`
+// at compile time so the second-PHY ports physically exist.
+//
+// Width mapping (also documented in DOC/integration_guide/integration_guide.md):
+//   FDI_CFG_SP_32B      -> WD0=256,  WD1=512   (single PHY, RX accumulates two
+//                                                256b phases into 512b internally)
+//   FDI_CFG_SP_64B      -> WD0=512,  WD1=512   (single PHY)
+//   FDI_CFG_SP_128B     -> WD0=1024, WD1=1024  (single PHY)
+//   FDI_CFG_TP_32B_64B  -> WD0=256,  WD1=512   (two PHY)
+//   FDI_CFG_TP_64B_128B -> WD0=512,  WD1=1024  (two PHY)
+//
+// Note: SP_32B and TP_32B_64B produce identical width pairs; only
+// `+define+TWO_PHY` distinguishes them. Consistency between FDI_CONFIG and
+// the presence/absence of `+define+TWO_PHY` is the integrator's
+// responsibility; no in-RTL elaboration check is added.
+// ----------------------------------------------------------------------------
+parameter int FDI_CFG_SP_32B      = 0;
+parameter int FDI_CFG_SP_64B      = 1;
+parameter int FDI_CFG_SP_128B     = 2;
+parameter int FDI_CFG_TP_32B_64B  = 3;
+parameter int FDI_CFG_TP_64B_128B = 4;
 
 parameter logic [7:0] CREDIT_TABLE [7:0] = '{
     8'd128,

--- a/VERIF/aou_tb.f
+++ b/VERIF/aou_tb.f
@@ -1,11 +1,32 @@
-// =============================================================================
+// *****************************************************************************
+// SPDX-License-Identifier: Apache-2.0
+// *****************************************************************************
+//  Copyright (c) 2026 Tenstorrent USA Inc
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// *****************************************************************************
 // AOU_CORE_TOP AXI VIP Testbench -- File List
 // All paths relative to the VERIF/ directory
 // =============================================================================
-+define+TWO_PHY
-+define+FDI_32B
-+define+FDI_64B
-//+define+FDI_128B
+// FDI data widths are now SystemVerilog parameters (FDI_IF_WD0 / FDI_IF_WD1)
+// on AOU_CORE_TOP and AOU_TOP. The +define+FDI_32B / FDI_64B / FDI_128B
+// preprocessor switches have been removed; aou_tb.sv overrides the
+// parameters on each DUT instance.
+//
+// TWO_PHY is intentionally NOT defined here: the parameter-refactor scope is
+// single-PHY only. AOU_TOP and AOU_CORE_TOP both wrap the second-PHY ports
+// and the I_PHY_TYPE port in `ifdef TWO_PHY` so the single-PHY build does
+// not require it. TWO_PHY enablement is tracked in a separate change.
 
 // Include paths
 +incdir+axi_vip/include
@@ -84,6 +105,8 @@ axi_vip/src/axi_sim_mem.sv
 ../RTL/AOU_CORE_RP.sv
 ../RTL/AOU_CORE.sv
 ../RTL/AOU_CORE_TOP.sv
+../RTL/AOU_FDI_BRINGUP_CTRL.sv
+../RTL/AOU_TOP.sv
 
 // FDI flit decoder (must precede testbench)
 decoder/fdi_flit_decoder.sv

--- a/VERIF/aou_tb.sv
+++ b/VERIF/aou_tb.sv
@@ -650,44 +650,37 @@ module aou_tb;
 `endif // AXI_LOG
 
     // ================================================================
-    // FDI cross-connect wires (64B)
+    // FDI cross-connect wires (single-PHY 32B: FDI_IF_WD0 = 256b)
     // u_dut1 TX LP -> u_dut2 RX PL (request path)
     // u_dut2 TX LP -> u_dut1 RX PL (response path)
+    //
+    // The TWO_PHY second-PHY ports (_1, 512b) are gated out of AOU_CORE_TOP
+    // when +define+TWO_PHY is not set, so only the _0 (256b) nets are used.
     // ================================================================
-    wire [511:0] dut1_lp_64b_data;
-    wire         dut1_lp_64b_valid;
-    wire         dut1_lp_64b_irdy;
-    wire         dut1_lp_64b_stallack;
-
-    wire [511:0] dut2_lp_64b_data;
-    wire         dut2_lp_64b_valid;
-    wire         dut2_lp_64b_irdy;
-    wire         dut2_lp_64b_stallack;
-
-`ifdef AXI_LOG
-    fdi_flit_decoder #(.LOG_FILE("dut1_fdi.log"), .FDI_BYTES(64)) u_fdi_dec1 (
-        .clk    (clk),
-        .resetn (resetn),
-        .valid  (dut1_lp_64b_valid),
-        .data   (dut1_lp_64b_data)
-    );
-    fdi_flit_decoder #(.LOG_FILE("dut2_fdi.log"), .FDI_BYTES(64)) u_fdi_dec2 (
-        .clk    (clk),
-        .resetn (resetn),
-        .valid  (dut2_lp_64b_valid),
-        .data   (dut2_lp_64b_data)
-    );
-`endif
-
-    // 32B LP outputs (unused, just observed)
     wire [255:0] dut1_lp_32b_data;
     wire         dut1_lp_32b_valid;
     wire         dut1_lp_32b_irdy;
     wire         dut1_lp_32b_stallack;
+
     wire [255:0] dut2_lp_32b_data;
     wire         dut2_lp_32b_valid;
     wire         dut2_lp_32b_irdy;
     wire         dut2_lp_32b_stallack;
+
+`ifdef AXI_LOG
+    fdi_flit_decoder #(.LOG_FILE("dut1_fdi.log"), .FDI_BYTES(32)) u_fdi_dec1 (
+        .clk    (clk),
+        .resetn (resetn),
+        .valid  (dut1_lp_32b_valid),
+        .data   (dut1_lp_32b_data)
+    );
+    fdi_flit_decoder #(.LOG_FILE("dut2_fdi.log"), .FDI_BYTES(32)) u_fdi_dec2 (
+        .clk    (clk),
+        .resetn (resetn),
+        .valid  (dut2_lp_32b_valid),
+        .data   (dut2_lp_32b_data)
+    );
+`endif
 
     // u_dut1 error/status outputs
     wire d1_int_req_linkreset;
@@ -716,6 +709,10 @@ module aou_tb;
     // ================================================================
     AOU_CORE_TOP #(
         .RP_COUNT    (RP_COUNT),
+        // Preserve legacy +define+FDI_32B single-PHY behavior using the
+        // single FDI_CONFIG parameter (resolves to WD0=256, WD1=512).
+        // TWO_PHY is no longer defined for this refactor scope.
+        .FDI_CONFIG  (packet_def_pkg::FDI_CFG_SP_32B),
         .APB_ADDR_WD (APB_ADDR_WD),
         .APB_DATA_WD (APB_DATA_WD)
     ) u_dut1 (
@@ -812,32 +809,19 @@ module aou_tb;
         .O_AOU_RX_AXI_S_BVALID       (axi_s_bvalid),
         .I_AOU_RX_AXI_S_BREADY       (axi_s_bready),
 
-        // PHY
-        .I_PHY_TYPE                   (1'b1),
-
-        // FDI 0 (it could be 32B / 64B) (unused)
-        .I_FDI_PL_0_VALID           (1'b0),
-        .I_FDI_PL_0_DATA            (256'b0),
+        // FDI 0 (single-PHY 32B / 256b): RX takes u_dut2's TX, TX feeds u_dut2's RX.
+        // Second-PHY ports (_1) and I_PHY_TYPE are gated by `ifdef TWO_PHY` in
+        // AOU_CORE_TOP and therefore not instantiated in this single-PHY build.
+        .I_FDI_PL_0_VALID           (dut2_lp_32b_valid),
+        .I_FDI_PL_0_DATA            (dut2_lp_32b_data),
         .I_FDI_PL_0_FLIT_CANCEL     (1'b0),
-        .I_FDI_PL_0_TRDY            (1'b0),
+        .I_FDI_PL_0_TRDY            (1'b1),
         .I_FDI_PL_0_STALLREQ        (1'b0),
-        .I_FDI_PL_0_STATE_STS       (4'h0),
+        .I_FDI_PL_0_STATE_STS       (4'h1),
         .O_FDI_LP_0_DATA            (dut1_lp_32b_data),
         .O_FDI_LP_0_VALID           (dut1_lp_32b_valid),
         .O_FDI_LP_0_IRDY            (dut1_lp_32b_irdy),
         .O_FDI_LP_0_STALLACK        (dut1_lp_32b_stallack),
-
-        // FDI 1 (if could be 64B / 128B) -- RX from u_dut1 TX, TX outputs cross back to u_dut1 RX
-        .I_FDI_PL_1_VALID           (dut2_lp_64b_valid),
-        .I_FDI_PL_1_DATA            (dut2_lp_64b_data),
-        .I_FDI_PL_1_FLIT_CANCEL     (1'b0),
-        .I_FDI_PL_1_TRDY            (1'b1),
-        .I_FDI_PL_1_STALLREQ        (1'b0),
-        .I_FDI_PL_1_STATE_STS       (4'h1),
-        .O_FDI_LP_1_DATA            (dut1_lp_64b_data),
-        .O_FDI_LP_1_VALID           (dut1_lp_64b_valid),
-        .O_FDI_LP_1_IRDY            (dut1_lp_64b_irdy),
-        .O_FDI_LP_1_STALLACK        (dut1_lp_64b_stallack),
 
         // Error / status
         .INT_REQ_LINKRESET            (d1_int_req_linkreset),
@@ -868,6 +852,10 @@ module aou_tb;
         .RP1_AXI_DATA_WD (D2_AXI_DATA_WIDTH),
         .RP2_AXI_DATA_WD (D2_AXI_DATA_WIDTH),
         .RP3_AXI_DATA_WD (D2_AXI_DATA_WIDTH),
+        // Preserve legacy +define+FDI_32B single-PHY behavior using the
+        // single FDI_CONFIG parameter (resolves to WD0=256, WD1=512).
+        // TWO_PHY is no longer defined for this refactor scope.
+        .FDI_CONFIG      (packet_def_pkg::FDI_CFG_SP_32B),
         .APB_ADDR_WD     (APB_ADDR_WD),
         .APB_DATA_WD     (APB_DATA_WD)
     ) u_dut2 (
@@ -964,32 +952,19 @@ module aou_tb;
         .O_AOU_RX_AXI_S_BVALID       (d2_axi_s_bvalid),
         .I_AOU_RX_AXI_S_BREADY       (d2_axi_s_bready),
 
-        // PHY
-        .I_PHY_TYPE                   (1'b1),
-
-        // FDI 0 (it could be 32B / 64B) (unused)
-        .I_FDI_PL_0_VALID           (1'b0),
-        .I_FDI_PL_0_DATA            (256'b0),
+        // FDI 0 (single-PHY 32B / 256b): RX takes u_dut1's TX, TX feeds u_dut1's RX.
+        // Second-PHY ports (_1) and I_PHY_TYPE are gated by `ifdef TWO_PHY` in
+        // AOU_CORE_TOP and therefore not instantiated in this single-PHY build.
+        .I_FDI_PL_0_VALID           (dut1_lp_32b_valid),
+        .I_FDI_PL_0_DATA            (dut1_lp_32b_data),
         .I_FDI_PL_0_FLIT_CANCEL     (1'b0),
-        .I_FDI_PL_0_TRDY            (1'b0),
+        .I_FDI_PL_0_TRDY            (1'b1),
         .I_FDI_PL_0_STALLREQ        (1'b0),
-        .I_FDI_PL_0_STATE_STS       (4'h0),
+        .I_FDI_PL_0_STATE_STS       (4'h1),
         .O_FDI_LP_0_DATA            (dut2_lp_32b_data),
         .O_FDI_LP_0_VALID           (dut2_lp_32b_valid),
         .O_FDI_LP_0_IRDY            (dut2_lp_32b_irdy),
         .O_FDI_LP_0_STALLACK        (dut2_lp_32b_stallack),
-
-        // FDI 1 (if could be 64B / 128B) -- RX from u_dut1 TX, TX outputs cross back to u_dut1 RX
-        .I_FDI_PL_1_VALID           (dut1_lp_64b_valid),
-        .I_FDI_PL_1_DATA            (dut1_lp_64b_data),
-        .I_FDI_PL_1_FLIT_CANCEL     (1'b0),
-        .I_FDI_PL_1_TRDY            (1'b1),
-        .I_FDI_PL_1_STALLREQ        (1'b0),
-        .I_FDI_PL_1_STATE_STS       (4'h1),
-        .O_FDI_LP_1_DATA            (dut2_lp_64b_data),
-        .O_FDI_LP_1_VALID           (dut2_lp_64b_valid),
-        .O_FDI_LP_1_IRDY            (dut2_lp_64b_irdy),
-        .O_FDI_LP_1_STALLACK        (dut2_lp_64b_stallack),
 
         // Error / status
         .INT_REQ_LINKRESET            (d2_int_req_linkreset),

--- a/scripts/run_lint.sh
+++ b/scripts/run_lint.sh
@@ -12,6 +12,10 @@
 #   - Implicit net declarations (IMPLICIT)
 #   - Incomplete case statements (CASEINCOMPLETE)
 #
+# Scope: AOU_TOP (the turnkey FDI bringup wrapper around AOU_CORE_TOP).
+# The single-PHY parameter configuration is exercised; TWO_PHY ports are
+# gated by `ifdef TWO_PHY` and excluded from this build.
+#
 # Usage:  bash scripts/run_lint.sh
 #         (run from the repository root)
 #


### PR DESCRIPTION
Replace the +define+FDI_32B / FDI_64B / FDI_128B preprocessor switches with a single FDI_CONFIG integer parameter on AOU_TOP and AOU_CORE_TOP. Configuration is now per-instance rather than per-build, and integrators pick an enumerated configuration instead of plumbing internal per-PHY widths themselves.

RTL changes:
- packet_def_pkg.sv: add FDI_CFG_SP_32B / SP_64B / SP_128B / TP_32B_64B / TP_64B_128B integer constants with a width-mapping doc block.
- AOU_CORE_TOP.sv, AOU_TOP.sv: expose parameter int FDI_CONFIG = FDI_CFG_SP_32B; derive internal FDI_IF_WD0 / FDI_IF_WD1 localparams from FDI_CONFIG and use them to size ports, FIFO-depth ternaries, and the RX_*_FIFO_RS_EN register-slice controls. AOU_TOP forwards FDI_CONFIG only to u_aou_core_top. FDI ports renamed from _32B/_64B to _0/_1; I_PHY_TYPE and all PHY1 ports are gated by `ifdef TWO_PHY`.
- AOU_CORE, AOU_TX_CORE: collapse FIFO-depth, RX input-mux, and TX flit-packing ifdef blocks into parameter-driven localparams and generate-if blocks.
- filelist.f, aou_tb.f: drop the legacy +define+FDI_* and +define+TWO_PHY switches; re-include AOU_TOP and AOU_FDI_BRINGUP_CTRL.

X-injection / LEC fixes (refactor 'index out of range' indexed selects into explicit one-hot muxes to remove unreachable bins that LEC injects X into):
- AOU_DATA_R_FIFO_NS1M, AOU_DATA_W_FIFO_NS1M, AOU_SYNC_FIFO_NS1M, AOU_SYNC_FIFO_REG: rewrite read/write paths as one-hot muxes over the actual FIFO depth instead of relying on power-of-two indexing.
- AOU_RX_CORE: introduce f_g_others / f_g_msg_type helper functions to encapsulate the one-hot mux for r_g[*][gid].field selects (gid is 4b but the array has 12 entries).

Verification / scripts:
- VERIF/aou_tb.sv: single-PHY 32B (256b) loopback through the _0 ports; fdi_flit_decoder uses FDI_BYTES=32; DUTs overridden with .FDI_CONFIG(packet_def_pkg::FDI_CFG_SP_32B).
- scripts/run_lint.sh: top is now AOU_TOP.
- scripts/lec/lec_SP_{32B,64B,128B}.do use -parameter FDI_CONFIG <int> on the revised side.

Documentation:
- integration_guide.md: refresh Section 1.2.2 (key features), Section 2 (parameter table adds FDI_CONFIG, RX_*_FIFO_RS_EN, FDI-aware FIFO depth defaults, and a +define+TWO_PHY build-flag note; RP_COUNT default fixed to 1), Section 3.10 (FDI port table uses _0/_1 naming and parameterized widths, with TWO_PHY gating for PHY1 and I_PHY_TYPE), Section 6.6.4 (PHY-type mux is TWO_PHY-only), Section 7 (testbench described as single-PHY 32B/256b loopback), Section 8.6 (UPF scope clarified for AOU_TOP vs AOU_CORE_TOP integration).
- aou_core_mas.md: refresh Sections 1.1, 2.1, 3.1, 3.4 for 128B chunk support and FDI-config-aware Data FIFO depth defaults; Section 6 introduces AOU_TOP as a wrapper option; Section 6.1 Table 5 reorganized into PHY0 (always present) and PHY1 (TWO_PHY only) blocks with parameterized widths; Section 6.4 Table 6 adds FDI_CONFIG, RX_*_FIFO_RS_EN, FDI-aware FIFO depths, and +define+TWO_PHY; Section 8.3 qualifies area numbers; Appendix A logs the revision; Appendix B Table 12 references the AoU 0.7 specification at openchipletatlas.org.
- README.md: intro, directory structure, documentation links, and integration section refer to AOU_TOP and AOU_CORE_TOP and link to the integration guide and MAS at their correct paths/sections.

All modified files include the Tenstorrent copyright alongside the existing BOS Semiconductors copyright per project policy. TWO_PHY is intentionally not exercised by lint or aou_tb in this change; the second-PHY ports remain wrapped in `ifdef TWO_PHY` for future re-enablement. No in-RTL elaboration check for FDI_CONFIG vs +define+TWO_PHY consistency is added; that responsibility is documented in the integration guide. Verilator and Verible lint report only pre-existing warnings; no new findings introduced.

Made-with: Cursor