### PR TITLE
chore: move packet_def_pkg import into module header scope

### DIFF
--- a/RTL/AOU_CORE.sv
+++ b/RTL/AOU_CORE.sv
@@ -26,9 +26,9 @@
 
 `timescale 1ns/1ps
 
+module AOU_CORE
 import packet_def_pkg::*;
-
-module AOU_CORE #(
+#(
     parameter   RP0_RX_AW_FIFO_DEPTH        = 40,
     parameter   RP0_RX_AR_FIFO_DEPTH        = 40,
     parameter   RP0_RX_W_FIFO_DEPTH         = 80,

--- a/RTL/AOU_CORE_RP.sv
+++ b/RTL/AOU_CORE_RP.sv
@@ -25,9 +25,9 @@
 
 `timescale 1ns/1ps
 
+module AOU_CORE_RP
 import packet_def_pkg::*;
-
-module AOU_CORE_RP #(
+#(
 
     parameter   AXI_DATA_WD                 = 512,
     parameter   AXI_PEER_DIE_MAX_DATA_WD    = 1024,

--- a/RTL/AOU_RX_CORE.sv
+++ b/RTL/AOU_RX_CORE.sv
@@ -26,9 +26,8 @@
 
 `timescale 1ns/1ps
 
-import packet_def_pkg::*;
 module AOU_RX_CORE
-
+import packet_def_pkg::*;
 #(
     parameter   PHY_TYPE                    = 2, //0:32B, 1:64B, 2:128B, 3:256B
     parameter   FDI_IF_WD                   = 1024,

--- a/RTL/AOU_TX_AXI_BUFFER.sv
+++ b/RTL/AOU_TX_AXI_BUFFER.sv
@@ -24,8 +24,9 @@
 // *****************************************************************************
 
 `timescale 1ns/1ps
-import packet_def_pkg::*; 
+
 module AOU_TX_AXI_BUFFER
+import packet_def_pkg::*;
 #(
     parameter   RP_CNT                  = 4,
     parameter   RP0_AXI_DATA_WD         = 512,

--- a/RTL/AOU_TX_CORE.sv
+++ b/RTL/AOU_TX_CORE.sv
@@ -26,9 +26,8 @@
 
 `timescale 1ns/1ps
 
-import packet_def_pkg::*;
 module AOU_TX_CORE
-
+import packet_def_pkg::*;
 #(
     parameter   RP_CNT              = 4,
     parameter   RP0_AXI_DATA_WD     = 512,


### PR DESCRIPTION
Five RTL files imported packet_def_pkg::* at the compilation-unit (global) scope, leaking the package namespace into every file compiled in the same unit and creating ordering/visibility issues when these files are pulled into different compilation contexts (lint, LEC, formal, verification, third-party integrations).

Move the import inside each module header using the SystemVerilog 'module Foo import packet_def_pkg::*; #(...) (...);' form so the symbols are only visible inside the module that uses them. This matches the pattern already used by AOU_TOP, AOU_CORE_TOP, AOU_TX_CRD_CTRL, AOU_RX_CRD_CTRL, and AOU_CRD_CTRL.

Files updated:
  RTL/AOU_CORE.sv
  RTL/AOU_CORE_RP.sv
  RTL/AOU_RX_CORE.sv
  RTL/AOU_TX_AXI_BUFFER.sv
  RTL/AOU_TX_CORE.sv

No functional change.

Made-with: Cursor