### PR TITLE
ci: migrate workflows to Node 24 and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Tenstorrent USA Inc
+#
+# Dependabot watches our GitHub Actions pins and Python deps and files
+# weekly grouped PRs when newer versions are available. Helps us catch
+# runtime deprecations (like the Node 20 -> Node 24 migration) before
+# they show up as warnings in CI.
+
+version: 2
+updates:
+  # GitHub Actions used by all .github/workflows/*.yml files.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+
+  # Top-level Python deps (peakrdl + IP-XACT validation).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      python:
+        patterns: ["*"]
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps"
+
+  # Cocotb testbench Python deps.
+  - package-ecosystem: "pip"
+    directory: "/VERIF"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      cocotb:
+        patterns: ["*"]
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "verif"

--- a/.github/workflows/branch-name-check.yaml
+++ b/.github/workflows/branch-name-check.yaml
@@ -24,13 +24,13 @@ jobs:
 
           echo "Branch name: $BRANCH"
 
-          PATTERN="^(feature|bugfix|hotfix|chore)/"
+          PATTERN="^(feature|bugfix|hotfix|chore|dependabot)/"
 
           if [[ "$BRANCH" =~ $PATTERN ]]; then
             echo "Branch name '$BRANCH' follows the naming convention."
           else
             echo "::error::Branch name '$BRANCH' does not follow the required naming convention."
-            echo "Branch names must start with one of: feature/, bugfix/, hotfix/, chore/"
+            echo "Branch names must start with one of: feature/, bugfix/, hotfix/, chore/, dependabot/"
             echo "Examples: feature/add-fdi-support, bugfix/fix-clock-gating, hotfix/critical-reset, chore/update-ci"
             exit 1
           fi

--- a/.github/workflows/cocotb.yml
+++ b/.github/workflows/cocotb.yml
@@ -18,20 +18,28 @@ on:
 permissions:
   contents: read
 
+env:
+  # Force Node 24 for any third-party action still pinned to Node 20
+  # (notably veryl-lang/setup-verilator@v1). GitHub-maintained actions
+  # below are already on Node-24-capable majors.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   cocotb:
     name: Verilator + cocotb
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Install Verilator 5.046
+      - name: Install Verilator 5.044
         uses: veryl-lang/setup-verilator@v1
         with:
-          verilator_version: "5.046"
+          # veryl-lang/verilator-package only ships up to v5.044 (newer
+          # tags exist upstream but have no pre-built binary yet).
+          version: "5.044"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -49,14 +57,14 @@ jobs:
 
       - name: Upload cocotb log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cocotb-log
           path: logs/cocotb.log
 
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cocotb-results-xml
           path: VERIF/results.xml

--- a/.github/workflows/gen-collateral.yml
+++ b/.github/workflows/gen-collateral.yml
@@ -30,10 +30,10 @@ jobs:
     name: peakrdl gen_collateral.sh
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload gen_collateral log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gen-collateral-log
           path: logs/gen_collateral.log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,12 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  # Force Node 24 for any third-party action still pinned to Node 20
+  # (notably veryl-lang/setup-verilator@v1). GitHub-maintained actions
+  # below are already on Node-24-capable majors.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   verible:
     name: Verible Style Lint
@@ -26,7 +32,7 @@ jobs:
     env:
       VERIBLE_VERSION: "v0.0-4053-g89d4d98a"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verible lint with inline PR comments
         uses: chipsalliance/verible-linter-action@main
@@ -51,7 +57,7 @@ jobs:
 
       - name: Upload Verible log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: verible-lint-log
           path: logs/verible_lint.log
@@ -61,19 +67,21 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Install Verilator 5.046
+      - name: Install Verilator 5.044
         uses: veryl-lang/setup-verilator@v1
         with:
-          verilator_version: "5.046"
+          # veryl-lang/verilator-package only ships up to v5.044 (newer
+          # tags exist upstream but have no pre-built binary yet).
+          version: "5.044"
 
       - name: Run Verilator lint
         run: bash scripts/run_lint.sh || true
 
       - name: Upload Verilator log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: verilator-lint-log
           path: logs/verilator_lint.log


### PR DESCRIPTION
Bump all GitHub-maintained actions in the three workflows to their first Node-24-capable major versions, and add a workflow-scope FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true escape hatch on the two workflows that still pull in veryl-lang/setup-verilator@v1 (no Node 24 release yet upstream). Clears the Node 20 deprecation warning ahead of the June 2026 default flip and the September 2026 removal.

  - actions/checkout@v4 -> @v5
  - actions/setup-python@v5 -> @v6
  - actions/upload-artifact@v4 -> @v6

Add .github/dependabot.yml so future runtime / package deprecations surface as weekly grouped PRs (github-actions at root, pip at root and VERIF/) instead of as silent CI warnings we have to chase manually.

Extend the branch-name-check regex to allow the dependabot/* prefix that Dependabot hard-codes on its PR branches; without this every Dependabot PR would red-fail the convention check and be unmergeable.

Made-with: Cursor