### PR TITLE
ci: scope CODEOWNERS review and enforce CSR markdown drift check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # Default: no required reviewers. PRs touching only paths not listed below
 # (e.g. DOC/, INTEG/, scripts/, .github/, root files) can merge without a
 # Code Owner approval. Status checks defined by branch protection still apply.
-*
 
 # Protected design + verification + register source: require review from the
 # maintainers team before merge into main.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,10 @@
-* @tenstorrent/aou-rtl-maintainers
+# Default: no required reviewers. PRs touching only paths not listed below
+# (e.g. DOC/, INTEG/, scripts/, .github/, root files) can merge without a
+# Code Owner approval. Status checks defined by branch protection still apply.
+*
+
+# Protected design + verification + register source: require review from the
+# maintainers team before merge into main.
+/RTL/   @tenstorrent/aou-rtl-maintainers
+/VERIF/ @tenstorrent/aou-rtl-maintainers
+/csr/   @tenstorrent/aou-rtl-maintainers

--- a/.github/workflows/gen-collateral.yml
+++ b/.github/workflows/gen-collateral.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/gen_collateral.sh'
       - 'requirements.txt'
       - '.github/workflows/gen-collateral.yml'
+      - 'DOC/csr/aou-core-csrs.md'
   push:
     branches: [main, design]
     paths:
@@ -21,6 +22,7 @@ on:
       - 'scripts/gen_collateral.sh'
       - 'requirements.txt'
       - '.github/workflows/gen-collateral.yml'
+      - 'DOC/csr/aou-core-csrs.md'
 
 permissions:
   contents: read
@@ -46,6 +48,14 @@ jobs:
           mkdir -p logs
           set -o pipefail
           bash scripts/gen_collateral.sh 2>&1 | tee logs/gen_collateral.log
+
+      - name: Verify DOC/csr/aou-core-csrs.md is up to date
+        run: |
+          if ! git diff --exit-code -- DOC/csr/aou-core-csrs.md; then
+            echo "::error file=DOC/csr/aou-core-csrs.md::DOC/csr/aou-core-csrs.md is out of date with csr/aou-core.rdl."
+            echo "Run 'bash scripts/gen_collateral.sh' locally and commit the regenerated DOC/csr/aou-core-csrs.md as part of this PR."
+            exit 1
+          fi
 
       - name: Upload gen_collateral log
         if: always()


### PR DESCRIPTION
Narrow .github/CODEOWNERS so only RTL/, VERIF/, and csr/ require maintainer Code Owner review; documentation, integration, scripts, and .github/ changes fall under an unowned wildcard so they can merge without an external approval once the accompanying branch-protection update (required approvals = 0, Require review from Code Owners = ON, Allow auto-merge = OFF) is applied in the GitHub UI. Also extends .github/workflows/gen-collateral.yml to fail CI when the regenerated DOC/csr/aou-core-csrs.md does not byte-match the committed copy, and triggers the workflow on direct edits to that file, so the only checked-in CSR collateral cannot silently drift from csr/aou-core.rdl.