### PR TITLE
ci: always-run gen-collateral and cocotb so required checks don't hang

### DIFF
--- a/.github/workflows/cocotb.yml
+++ b/.github/workflows/cocotb.yml
@@ -8,17 +8,23 @@
 #
 # Fatal: any failing @cocotb.test red-fails the matrix entry. With
 # fail-fast: false, one variant failing does not cancel the others.
+#
+# This workflow triggers on every PR/push, but the heavy steps in each
+# matrix entry are gated by a single `detect` job that uses
+# dorny/paths-filter to decide whether simulation-relevant paths
+# changed. When nothing relevant changed, each "Verilator + cocotb (...)"
+# matrix entry still runs on a runner long enough to report success, so
+# any required-status-check wiring on `main` for these names is
+# satisfied for doc / .github-only PRs that have no sim impact. See
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks
+# for the underlying GitHub behavior this works around.
 
 name: Cocotb Verification
 
 on:
   pull_request:
-    paths-ignore:
-      - 'DOC/**'
   push:
     branches: [main, design]
-    paths-ignore:
-      - 'DOC/**'
 
 permissions:
   contents: read
@@ -30,7 +36,29 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  detect:
+    name: Detect simulation-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      sim: ${{ steps.filter.outputs.sim }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run paths filter
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sim:
+              - 'RTL/**'
+              - 'VERIF/**'
+              - 'csr/**'
+              - 'scripts/**'
+              - 'requirements.txt'
+              - '.github/workflows/cocotb.yml'
+
   cocotb:
+    needs: detect
     name: "Verilator + cocotb (${{ matrix.fdi_config }})"
     runs-on: ubuntu-latest
     strategy:
@@ -38,9 +66,15 @@ jobs:
       matrix:
         fdi_config: [sp32b, sp64b, sp128b]
     steps:
+      - name: Skip notice
+        if: needs.detect.outputs.sim != 'true'
+        run: echo "No simulation-relevant paths changed; skipping cocotb (${{ matrix.fdi_config }})."
+
       - uses: actions/checkout@v6
+        if: needs.detect.outputs.sim == 'true'
 
       - name: Install Verilator 5.044
+        if: needs.detect.outputs.sim == 'true'
         uses: veryl-lang/setup-verilator@v2
         with:
           # veryl-lang/verilator-package only ships up to v5.044 (newer
@@ -48,6 +82,7 @@ jobs:
           version: "5.044"
 
       - name: Set up Python
+        if: needs.detect.outputs.sim == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -55,9 +90,11 @@ jobs:
           cache-dependency-path: VERIF/requirements.txt
 
       - name: Install cocotb dependencies
+        if: needs.detect.outputs.sim == 'true'
         run: pip install -r VERIF/requirements.txt
 
       - name: Run cocotb testbench
+        if: needs.detect.outputs.sim == 'true'
         working-directory: VERIF
         run: |
           mkdir -p ../logs
@@ -66,14 +103,14 @@ jobs:
             | tee ../logs/cocotb_${{ matrix.fdi_config }}.log
 
       - name: Upload cocotb log
-        if: always()
+        if: always() && needs.detect.outputs.sim == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: cocotb-log-${{ matrix.fdi_config }}
           path: logs/cocotb_${{ matrix.fdi_config }}.log
 
       - name: Upload JUnit results
-        if: always()
+        if: always() && needs.detect.outputs.sim == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: cocotb-results-xml-${{ matrix.fdi_config }}

--- a/.github/workflows/gen-collateral.yml
+++ b/.github/workflows/gen-collateral.yml
@@ -4,25 +4,22 @@
 # Runs scripts/gen_collateral.sh in CI and fails the job on any non-zero
 # exit from peakrdl (the script uses `set -euo pipefail`, so the first
 # peakrdl error short-circuits the run).
+#
+# This workflow triggers on every PR/push, but the heavy steps are gated
+# on dorny/paths-filter so they only do work when CSR-related paths
+# change. The job itself always reports success so the "peakrdl
+# gen_collateral.sh" check name -- which is wired into branch protection
+# as a required status check on `main` -- is satisfied for every PR,
+# including doc / infra / RTL-only PRs that have no CSR collateral
+# impact. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks
+# for the underlying GitHub behavior this works around.
 
 name: Generate Collateral
 
 on:
   pull_request:
-    paths:
-      - 'csr/**'
-      - 'scripts/gen_collateral.sh'
-      - 'requirements.txt'
-      - '.github/workflows/gen-collateral.yml'
-      - 'DOC/csr/aou-core-csrs.md'
   push:
     branches: [main, design]
-    paths:
-      - 'csr/**'
-      - 'scripts/gen_collateral.sh'
-      - 'requirements.txt'
-      - '.github/workflows/gen-collateral.yml'
-      - 'DOC/csr/aou-core-csrs.md'
 
 permissions:
   contents: read
@@ -34,22 +31,42 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Detect CSR-related changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            csr:
+              - 'csr/**'
+              - 'scripts/gen_collateral.sh'
+              - 'requirements.txt'
+              - '.github/workflows/gen-collateral.yml'
+              - 'DOC/csr/aou-core-csrs.md'
+
+      - name: Skip notice
+        if: steps.changes.outputs.csr != 'true'
+        run: echo "No CSR-related paths changed; skipping gen_collateral.sh."
+
       - name: Set up Python
+        if: steps.changes.outputs.csr == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
 
       - name: Install peakrdl toolchain
+        if: steps.changes.outputs.csr == 'true'
         run: pip install -r requirements.txt
 
       - name: Run gen_collateral.sh
+        if: steps.changes.outputs.csr == 'true'
         run: |
           mkdir -p logs
           set -o pipefail
           bash scripts/gen_collateral.sh 2>&1 | tee logs/gen_collateral.log
 
       - name: Verify DOC/csr/aou-core-csrs.md is up to date
+        if: steps.changes.outputs.csr == 'true'
         run: |
           if ! git diff --exit-code -- DOC/csr/aou-core-csrs.md; then
             echo "::error file=DOC/csr/aou-core-csrs.md::DOC/csr/aou-core-csrs.md is out of date with csr/aou-core.rdl."
@@ -58,7 +75,7 @@ jobs:
           fi
 
       - name: Upload gen_collateral log
-        if: always()
+        if: always() && steps.changes.outputs.csr == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: gen-collateral-log

--- a/.github/workflows/gen-collateral.yml
+++ b/.github/workflows/gen-collateral.yml
@@ -7,11 +7,14 @@
 #
 # This workflow triggers on every PR/push, but the heavy steps are gated
 # on dorny/paths-filter so they only do work when CSR-related paths
-# change. The job itself always reports success so the "peakrdl
-# gen_collateral.sh" check name -- which is wired into branch protection
-# as a required status check on `main` -- is satisfied for every PR,
-# including doc / infra / RTL-only PRs that have no CSR collateral
-# impact. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks
+# change. The workflow always runs so the "peakrdl gen_collateral.sh"
+# check name -- which is wired into branch protection as a required
+# status check on `main` -- is present for every PR, including doc /
+# infra / RTL-only PRs that have no CSR collateral impact. When no
+# CSR-related paths changed, the heavy steps are skipped and the job
+# succeeds; otherwise it runs the collateral generation/verification
+# steps and may fail to block the PR. See
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks
 # for the underlying GitHub behavior this works around.
 
 name: Generate Collateral


### PR DESCRIPTION
Replace the path-trigger filters on both workflows with always-run jobs that use dorny/paths-filter to gate the heavy steps. The actual work (peakrdl gen + DOC/csr/aou-core-csrs.md drift check for gen-collateral, Verilator + cocotb for each FDI matrix entry) still only runs when CSR-related or simulation-relevant paths change, so CI cost on unrelated PRs is just a runner spin-up plus one filter call. The job names ("peakrdl gen_collateral.sh", "Verilator + cocotb (sp32b/sp64b/ sp128b)") are unchanged and now post a green status on every PR, which fixes the branch-protection hang where the gen-collateral required check sat in "Expected -- waiting for status" on doc / .github-only PRs that previously didn't trigger the workflow at all. cocotb shares a single `detect` job across its matrix so paths-filter runs once instead of three times.